### PR TITLE
Add emitted light from wielding spell tomes

### DIFF
--- a/mods/MODULES/gadgets_modpack/gadgets_api/api.lua
+++ b/mods/MODULES/gadgets_modpack/gadgets_api/api.lua
@@ -335,6 +335,7 @@ function gadgets.register_gadget(def)
     --Creating a temporary setting definition to pass to a on_use function
     local tdef = {
         mana_per_use = def.mana_per_use,
+        light_source = def.light_source,
         ammo_type = def.ammo_type,
         ammo_per_use = ammo_per_use,
         reload_sound = def.reload_sound,
@@ -372,6 +373,7 @@ function gadgets.register_gadget(def)
             stack_max = stack_max,
             liquids_pointable = false,
             groups = tool_groups,
+            light_source = def.light_source,
             on_use = function(itemstack, user, pointed_thing)
                 local stack = gadgets_on_use(itemstack, user, pointed_thing, tdef)
                 return stack
@@ -386,6 +388,7 @@ function gadgets.register_gadget(def)
             groups = tool_groups,
             on_refill = on_refill,
             wear_represents = wear_represents,
+            light_source = def.light_source,
             on_use = function(itemstack, user, pointed_thing)
                 local stack = gadgets_on_use(itemstack, user, pointed_thing, tdef)
                 return stack

--- a/mods/MODULES/gadgets_modpack/gadgets_magic/spellbooks.lua
+++ b/mods/MODULES/gadgets_modpack/gadgets_magic/spellbooks.lua
@@ -3,6 +3,7 @@ gadgets.register_gadget({
     description = "Tome Of Speed",
     texture = "gadgets_magic_tome_speed.png",
     mana_per_use = 100,
+    light_source = 8,
     conflicting_effects = {"gadgets_default_effects_speed_2"},
     effect = {"gadgets_default_effects_speed_1"},
     duration = 60,
@@ -22,6 +23,7 @@ gadgets.register_gadget({
     description = "Tome Of Jump",
     texture = "gadgets_magic_tome_jump.png",
     mana_per_use = 100,
+    light_source = 7,
     conflicting_effects = {"gadgets_default_effects_jump_2"},
     effect = {"gadgets_default_effects_jump_1"},
     duration = 60,
@@ -41,6 +43,7 @@ gadgets.register_gadget({
     description = "Tome Of Gravity",
     texture = "gadgets_magic_tome_gravity.png",
     mana_per_use = 100,
+    light_source = 3,
     conflicting_effects = {"gadgets_default_effects_gravity_2"},
     effect = {"gadgets_default_effects_gravity_1"},
     duration = 60,
@@ -60,6 +63,7 @@ gadgets.register_gadget({
     description = "Tome Of Blink",
     texture = "gadgets_magic_tome_blink.png",
     mana_per_use = 150,
+    light_source = 5,
     use_sound = "gadgets_magic_blink",
     use_sound_gain = 1,
 
@@ -151,6 +155,7 @@ gadgets.register_gadget({
     description = "Tome Of Magical Bridge",
     texture = "gadgets_magic_tome_magic_bridge.png",
     mana_per_use = 100,
+    light_source = 7,
     use_sound = "gadgets_magic_spell_cast",
     use_sound_gain = 1,
 
@@ -222,6 +227,7 @@ gadgets.register_gadget({
     description = "Tome Of Magical Light",
     texture = "gadgets_magic_tome_light.png",
     mana_per_use = 100,
+    light_source = 11,
     use_sound = "gadgets_magic_spell_cast",
     use_sound_gain = 1,
 


### PR DESCRIPTION
As promised in #39, here is the pull request. This adds different amounts of light to the spell books based on how the icon looks. With the tome of gravity, you can barely see your nose, but the tome of light lets you see a lot, but not as much as if you actually place a lantern by casting it. The other tomes are in bweapons and are registered though a different api.