### PR TITLE
Fix deprecated warnings on many mods

### DIFF
--- a/mods/MODULES/ambience/init.lua
+++ b/mods/MODULES/ambience/init.lua
@@ -323,7 +323,7 @@ local get_ambience = function(player)
 	local player_is_descending = false
 	local player_is_moving_horiz = false
 	local standing_in_water = false]]
-	local pos = player:getpos()
+	local pos = player:get_pos()
 	local skylit = is_skylit(pos)
 	node_at_upper_body = minetest.registered_nodes[minetest.get_node(vector.add(pos, {x=0,y=1.2,z=0})).name]
 	
@@ -350,8 +350,8 @@ local get_ambience = function(player)
 		lacunarity = 2.0,
 		flags = "defaults"
 	})
-	temp = tempmap:get2d({x = math.floor(pos.x+0.5), y = math.floor(pos.z+0.5)}) - pos.y*(20 / 90)
-	humid = humidmap:get2d({x = math.floor(pos.x+0.5), y = math.floor(pos.z+0.5)})
+	temp = tempmap:get_2d({x = math.floor(pos.x+0.5), y = math.floor(pos.z+0.5)}) - pos.y*(20 / 90)
+	humid = humidmap:get_2d({x = math.floor(pos.x+0.5), y = math.floor(pos.z+0.5)})
 	
 	if node_at_upper_body and node_at_upper_body.liquidtype ~= "none" then
 		if music then
@@ -421,7 +421,7 @@ local get_ambience = function(player)
 --	minetest.chat_send_all("Found " .. nodename .. pos.y )
 	
 	
-	if player:getpos().y < 0 and not skylit then
+	if player:get_pos().y < 0 and not skylit then
 		if music then
 			return {cave=cave, cave_frequent=cave_frequent, music=music}
 		else

--- a/mods/MODULES/bees/init.lua
+++ b/mods/MODULES/bees/init.lua
@@ -121,8 +121,8 @@
         --wax flying all over the place
         minetest.add_particle({
           pos = {x=pos.x, y=pos.y, z=pos.z},
-          vel = {x=math.random(-4,4),y=math.random(8),z=math.random(-4,4)},
-          acc = {x=0,y=-6,z=0},
+          velocity = {x=math.random(-4,4),y=math.random(8),z=math.random(-4,4)},
+          acceleration = {x=0,y=-6,z=0},
           expirationtime = 2,
           size = math.random(1,3),
           collisiondetection = false,
@@ -457,8 +457,8 @@
     action = function(pos)
       minetest.add_particle({
         pos = {x=pos.x, y=pos.y, z=pos.z},
-        vel = {x=(math.random()-0.5)*5,y=(math.random()-0.5)*5,z=(math.random()-0.5)*5},
-        acc = {x=math.random()-0.5,y=math.random()-0.5,z=math.random()-0.5},
+        velocity = {x=(math.random()-0.5)*5,y=(math.random()-0.5)*5,z=(math.random()-0.5)*5},
+        acceleration = {x=math.random()-0.5,y=math.random()-0.5,z=math.random()-0.5},
         expirationtime = math.random(2.5),
         size = math.random(3),
         collisiondetection = true,

--- a/mods/MODULES/bweapons_modpack/bweapons_api/api.lua
+++ b/mods/MODULES/bweapons_modpack/bweapons_api/api.lua
@@ -439,11 +439,11 @@ function bweapons.register_weapon(def)
                 mana.subtract(playername, def.mana_per_use)
             end
 
-            local playerpos = user:getpos()
+            local playerpos = user:get_pos()
             local dir = user:get_look_dir()
             local vel = {x = 0, y = 0, z = 0}
             if combine_velocity then
-                vel = user:get_player_velocity()
+                vel = user:get_velocity()
             end
 
             --Hitscan type, implemented in-place

--- a/mods/MODULES/ccompass/init.lua
+++ b/mods/MODULES/ccompass/init.lua
@@ -63,7 +63,7 @@ function ccompass.set_target(stack, param)
 	if param.playername then
 		local player = minetest.get_player_by_name(param.playername)
 		minetest.chat_send_player(param.playername, "Calibration done to "..param.target_name.." "..param.target_pos_string)
-		minetest.sound_play({ name = "ccompass_calibrate", gain = 1 }, { pos = player:getpos(), max_hear_distance = 3 })
+		minetest.sound_play({ name = "ccompass_calibrate", gain = 1 }, { pos = player:get_pos(), max_hear_distance = 3 })
 	end
 end
 
@@ -98,14 +98,14 @@ local function teleport_above(playername, target, counter)
 			break
 		end
 	end
-	player:setpos(target)
+	player:set_pos(target)
 	return
 end
 
 -- get right image number for players compas
 local function get_compass_stack(player, stack)
 	local target = get_destination(player, stack)
-	local pos = player:getpos()
+	local pos = player:get_pos()
 	local dir = player:get_look_horizontal()
 	local angle_north = math.deg(math.atan2(target.x - pos.x, target.z - pos.z))
 	if angle_north < 0 then

--- a/mods/MODULES/christmas_holiday_pack/presents_functions.lua
+++ b/mods/MODULES/christmas_holiday_pack/presents_functions.lua
@@ -13,7 +13,7 @@ christmas_holiday_pack.open_present = function (color)
     		local player_name = user:get_player_name()
     		local player = minetest.get_player_by_name(player_name)
     		local inv = player:get_inventory()
-    		local pos = player:getpos()
+    		local pos = player:get_pos()
     		
     		-- Select random loot
     		local item_drops = {}

--- a/mods/MODULES/climate/climate_api/ca_effects/particles.lua
+++ b/mods/MODULES/climate/climate_api/ca_effects/particles.lua
@@ -165,7 +165,7 @@ local function parse_config(player, particles)
 
 		-- correct spawn coordinates to adjust for player movement
 		if config.adjust_for_velocity then
-			local velocity = player:get_player_velocity()
+			local velocity = player:get_velocity()
 			config.minpos = vector.add(config.minpos, velocity)
 			config.maxpos = vector.add(config.maxpos, velocity)
 		end

--- a/mods/MODULES/climate/regional_weather/ca_weathers/ambient.lua
+++ b/mods/MODULES/climate/regional_weather/ca_weathers/ambient.lua
@@ -50,7 +50,7 @@ local function generate_effects(params)
 
 	override["climate_api:skybox"] = skybox
 
-	local movement = params.player:get_player_velocity()
+	local movement = params.player:get_velocity()
 	local movement_direction
 	if (vector.length(movement) < 0.1) then
 		movement_direction = vector.new(0, 0, 0)

--- a/mods/MODULES/cloudlands/cloudlands.lua
+++ b/mods/MODULES/cloudlands/cloudlands.lua
@@ -589,7 +589,7 @@ if ENABLE_PORTALS and minetest.get_modpath("nether") ~= nil and minetest.global_
       -- Hallelujah mountains start reaching the ground.
       if noise_heightMap == nil then cloudlands.init() end
       local largestCoreType  = cloudlands.coreTypes[1] -- the first island type is the biggest/thickest
-      local island_bottom = ALTITUDE - (largestCoreType.depthMax * 0.66) + round(noise_heightMap:get2d({x = pos.x, y = pos.z}))
+      local island_bottom = ALTITUDE - (largestCoreType.depthMax * 0.66) + round(noise_heightMap:get_2d({x = pos.x, y = pos.z}))
 
       return pos.y > math_max(40, island_bottom)
     end,
@@ -1352,7 +1352,7 @@ local function addCores(coreList, coreType, x1, z1, x2, z2)
         -- so rotate it a little to avoid it lining up with the world axis.
         local noiseX = ROTATE_COS * coreX - ROTATE_SIN * coreZ
         local noiseZ = ROTATE_SIN * coreX + ROTATE_COS * coreZ
-        local eddyField = noise_eddyField:get2d({x = noiseX, y = noiseZ})
+        local eddyField = noise_eddyField:get_2d({x = noiseX, y = noiseZ})
 
         if (math_abs(eddyField) < coreType.frequency) then
 
@@ -1361,8 +1361,8 @@ local function addCores(coreList, coreType, x1, z1, x2, z2)
             -- A 'nexus' is a made up name for a place where the eddyField is flat.
             -- There are often many 'field lines' leading out from a nexus.
             -- Like a saddle in the perlin noise the height "coreType.frequency"
-            local eddyField_orthA = noise_eddyField:get2d({x = noiseX + 2, y = noiseZ})
-            local eddyField_orthB = noise_eddyField:get2d({x = noiseX, y = noiseZ + 2})
+            local eddyField_orthA = noise_eddyField:get_2d({x = noiseX + 2, y = noiseZ})
+            local eddyField_orthB = noise_eddyField:get_2d({x = noiseX, y = noiseZ + 2})
             if math_abs(eddyField - eddyField_orthA) + math_abs(eddyField - eddyField_orthB) < 0.02 then
               nexusConditionMet = true
             end
@@ -1409,7 +1409,7 @@ local function addCores(coreList, coreType, x1, z1, x2, z2)
               if spaceConditionMet then
                 -- all conditions met, we've located a new island core
                 --minetest.log("Adding core "..x..","..y..","..z..","..radius)
-                local y = round(noise_heightMap:get2d({x = coreX, y = coreZ}))
+                local y = round(noise_heightMap:get_2d({x = coreX, y = coreZ}))
                 local newCore = {
                   x         = coreX,
                   y         = y,
@@ -1571,7 +1571,7 @@ cloudlands.get_height_at = function(x, z, coreList)
     if core.radius + core.depth > 80  then noise_weighting = 0.6  end
     if core.radius + core.depth > 120 then noise_weighting = 0.35 end
 
-    local surfaceNoise = noise_surfaceMap:get2d({x = x, y = z})
+    local surfaceNoise = noise_surfaceMap:get_2d({x = x, y = z})
     if DEBUG_GEOMETRIC then surfaceNoise = SURFACEMAP_OFFSET end
     local coreTop = ALTITUDE + core.y
     local surfaceHeight = coreTop + round(surfaceNoise * 3 * (core.thickness + 1) * horz_easing)
@@ -1585,7 +1585,7 @@ cloudlands.get_height_at = function(x, z, coreList)
       for y = math_max(coreTop, surfaceHeight), yBottom, -1 do
         local vert_easing = math_min(1, (y - coreBottom) / core.depth)
 
-        local densityNoise = noise_density:get3d({x = x, y = y - coreTop, z = z})
+        local densityNoise = noise_density:get_3d({x = x, y = y - coreTop, z = z})
         densityNoise = noise_weighting * densityNoise + (1 - noise_weighting) * DENSITY_OFFSET
         if DEBUG_GEOMETRIC then densityNoise = DENSITY_OFFSET end
 
@@ -1845,8 +1845,8 @@ local function addDetail_skyReef(decoration_list, core, data, area, minp, maxp)
       if distanceSquared < reefOuterRadiusSquared and distanceSquared > reefInnerRadiusSquared then
         pos.x = x
         local offsetEase = math_abs(distanceSquared - reefMiddleRadiusSquared) / reefHalfWidthSquared
-        local fineNoise = noise_skyReef:get2d(pos)
-        local reefNoise = (noiseOffset* offsetEase) + fineNoise + 0.2 * noise_surfaceMap:get2d(pos)
+        local fineNoise = noise_skyReef:get_2d(pos)
+        local reefNoise = (noiseOffset* offsetEase) + fineNoise + 0.2 * noise_surfaceMap:get_2d(pos)
 
         if (reefNoise > 0) then
           local distance = math_sqrt(distanceSquared)
@@ -2161,7 +2161,7 @@ local function addDetail_secrets(decoration_list, core, data, area, minp, maxp)
 
     local territoryX = math_floor(core.x / core.type.territorySize)
     local territoryZ = math_floor(core.z / core.type.territorySize)
-    local isPolarOutpost = (core.temperature <= 5) and (core.x % 3 == 0) and noise_surfaceMap:get2d({x = core.x, y = core.z - 8}) >= 0 --make sure steps aren't under a pond
+    local isPolarOutpost = (core.temperature <= 5) and (core.x % 3 == 0) and noise_surfaceMap:get_2d({x = core.x, y = core.z - 8}) >= 0 --make sure steps aren't under a pond
     local isAncientBurrow = core.humidity >= 60 and core.temperature >= 50
 
     -- only allow a checkerboard pattern of territories to help keep the secrets
@@ -2674,7 +2674,7 @@ local function renderCores(cores, minp, maxp, blockseed)
             end
           end
 
-          local surfaceNoise = noise_surfaceMap:get2d({x = x, y = z})
+          local surfaceNoise = noise_surfaceMap:get_2d({x = x, y = z})
           if DEBUG_GEOMETRIC then surfaceNoise = SURFACEMAP_OFFSET end
           local surface = round(surfaceNoise * 3 * (core.thickness + 1) * horz_easing) -- if you change this formular then update maxSufaceRise in on_generated()
           local coreBottom = math_floor(coreTop - (core.thickness + core.depth))
@@ -2692,7 +2692,7 @@ local function renderCores(cores, minp, maxp, blockseed)
             local vert_easing = math_min(1, (y - coreBottom) / core.depth)
 
             -- If you change the densityNoise calculation, remember to similarly update the copy of this calculation in the pond code
-            densityNoise = noise_density:get3d({x = x, y = y - coreTop, z = z}) -- TODO: Optimize this!!
+            densityNoise = noise_density:get_3d({x = x, y = y - coreTop, z = z}) -- TODO: Optimize this!!
             densityNoise = noise_weighting * densityNoise + (1 - noise_weighting) * DENSITY_OFFSET
 
             if DEBUG_GEOMETRIC then densityNoise = DENSITY_OFFSET end
@@ -2754,7 +2754,7 @@ local function renderCores(cores, minp, maxp, blockseed)
             if densityNoise == nil then
               -- Rare edge case. If the pond is at minp.y, then no land has been rendered, so
               -- densityNoise hasn't been calculated. Calculate it now.
-              densityNoise = noise_density:get3d({x = x, y = minp.y, z = z})
+              densityNoise = noise_density:get_3d({x = x, y = minp.y, z = z})
               densityNoise = noise_weighting * densityNoise + (1 - noise_weighting) * DENSITY_OFFSET
               if DEBUG_GEOMETRIC then densityNoise = DENSITY_OFFSET end
             end

--- a/mods/MODULES/death_messages/init.lua
+++ b/mods/MODULES/death_messages/init.lua
@@ -232,7 +232,7 @@ death_messages.messages.pushed = {
 minetest.register_globalstep(function(dtime)
 	for _,player in pairs(minetest.get_connected_players()) do
 		name = player:get_player_name()
-		if player:get_player_velocity().y < -13 then
+		if player:get_velocity().y < -13 then
 			death_messages.mightBeFalling[name] = 2.0
 		elseif death_messages.mightBeFalling[name] then
 			if death_messages.mightBeFalling[name] > 0 then
@@ -273,7 +273,7 @@ minetest.register_on_leaveplayer(death_messages.reset_watchers)
 
 minetest.register_on_dieplayer(function(player)
 	name = player:get_player_name()
-	local node = minetest.registered_nodes[minetest.get_node(player:getpos()).name]
+	local node = minetest.registered_nodes[minetest.get_node(player:get_pos()).name]
 	local message
 	--Death by entity
 	if death_messages.punched[name] and death_messages.punched[name] ~= name then

--- a/mods/MODULES/dfcaverns/bones_loot/init.lua
+++ b/mods/MODULES/dfcaverns/bones_loot/init.lua
@@ -23,7 +23,7 @@ if minetest.get_modpath("bones") then
 else
 
 	local function drop_item_stack(pos, stack)
-		if not stack or stack:is_empty() then return end
+		if not stack or not stack.is_empty or stack:is_empty() then return end
 		local drop_offset = vector.new(math.random() - 0.5, 0, math.random() - 0.5)
 		minetest.add_item(vector.add(pos, drop_offset), stack)
 	end

--- a/mods/MODULES/dfcaverns/subterrane/player_spawn.lua
+++ b/mods/MODULES/dfcaverns/subterrane/player_spawn.lua
@@ -133,7 +133,7 @@ function spawnplayer(cave_layer_def, player, ydepth)
 			local choice = math.random(1, table.getn(options))
 			local spawnpoint = options[ choice ]
 			minetest.log("action", "[subterrane] spawning player " .. minetest.pos_to_string(spawnpoint))
-			player:setpos(spawnpoint)
+			player:set_pos(spawnpoint)
 			return true
 		end
 	end

--- a/mods/MODULES/diet/init.lua
+++ b/mods/MODULES/diet/init.lua
@@ -93,7 +93,7 @@ function diet.item_eat(max, replace_with_item, poisen, heal)
 
 		-- Increase health
 		if minetest.get_modpath("hbhunger") and hbhunger then
-			minetest.sound_play({name = "hbhunger_eat_generic", gain = 1}, {pos=user:getpos(), max_hear_distance = 16})
+			minetest.sound_play({name = "hbhunger_eat_generic", gain = 1}, {pos=user:get_pos(), max_hear_distance = 16})
 
 			-- saturation
 			local h = tonumber(hbhunger.hunger[name])

--- a/mods/MODULES/fruit_tools/init.lua
+++ b/mods/MODULES/fruit_tools/init.lua
@@ -39,7 +39,7 @@ fruit_tools.path = minetest.get_modpath("fruit_tools")
 -- Sound effect function (unused as of now):
 local function play_sound_effect(player, name)
     if player then
-        local pos = player:getpos()
+        local pos = player:get_pos()
         if pos then
             minetest.sound_play({
                 pos = pos,

--- a/mods/MODULES/gadgets_modpack/gadgets_api/api.lua
+++ b/mods/MODULES/gadgets_modpack/gadgets_api/api.lua
@@ -121,7 +121,7 @@ local function gadgets_on_use(itemstack, user, pointed_thing, def)
         mana.subtract(playername, def.mana_per_use)
     end
 
-    local playerpos = user:getpos()
+    local playerpos = user:get_pos()
     local dir = user:get_look_dir()
 
     if def.return_item then

--- a/mods/MODULES/geomoria/mapgen.lua
+++ b/mods/MODULES/geomoria/mapgen.lua
@@ -114,14 +114,14 @@ local function generate(p_minp, p_maxp, seed)
       end
     end
 
-    damage_noise = damage_noise_map:get2dMap_flat({x=minp.x, y=minp.z}, damage_noise)
-    fissure_noise = fissure_noise_map:get3dMap_flat(minp, fissure_noise)
+    damage_noise = damage_noise_map:get_2d_map_flat({x=minp.x, y=minp.z}, damage_noise)
+    fissure_noise = fissure_noise_map:get_3d_map_flat(minp, fissure_noise)
   else
     heightmap = minetest.get_mapgen_object("heightmap")
     damage_noise = heightmap
     fissure_noise = heightmap
-    -- damage_noise = heightmap:get2dMap_flat({x=minp.x, y=minp.z}, damage_noise)
-    -- fissure_noise = heightmap:get3dMap_flat(minp, fissure_noise)
+    -- damage_noise = heightmap:get_2d_map_flat({x=minp.x, y=minp.z}, damage_noise)
+    -- fissure_noise = heightmap:get_3d_map_flat(minp, fissure_noise)
 
 	end
 

--- a/mods/MODULES/gramophone/api.lua
+++ b/mods/MODULES/gramophone/api.lua
@@ -85,7 +85,7 @@ gramophone.on_punch = function(pos, node, clicker, pointed_thing)
 					player_inv:add_item("main", disc)
 				end
 			else
-				minetest.add_item(clicker:getpos(), disc:get_name())
+				minetest.add_item(clicker:get_pos(), disc:get_name())
 			end
 			-- Clear values
 			disc_obj:remove()

--- a/mods/MODULES/hangglider/init.lua
+++ b/mods/MODULES/hangglider/init.lua
@@ -77,7 +77,7 @@ minetest.register_entity("hangglider:airstopper", { --A one-instant entity that 
 			if player:is_player() then
 				local pname = player:get_player_name()
 				canExist = true
-				if player:get_player_velocity().y < 0.5 and player:get_player_velocity().y > -0.5 then
+				if player:get_velocity().y < 0.5 and player:get_velocity().y > -0.5 then
 					--Let go when the player actually stops, as that's the whole point.
 					if hangglider.use[pname] then
 						if moveModelUp then
@@ -130,7 +130,7 @@ minetestd.physicsctl.register_physics_effect("hangglider",
 		return hangglider.use[player:get_player_name()]
 	end,
 	function(phys, player) -- blend
-		local vel_y = player:get_player_velocity().y
+		local vel_y = player:get_velocity().y
 		if debug then player:hud_change(hangglider.debug[pname].id, "text", vel_y..', '..player:get_physics_override().gravity..', '..tostring(hangglider.airbreak[pname])) end
 		phys.gravity = phys.gravity*((vel_y + 3)/20)
 		if vel_y < 0 and vel_y > -3 then
@@ -211,7 +211,7 @@ minetest.register_entity("hangglider:glider", {
 		if self.object:get_attach() then
 			local player = self.object:get_attach("parent")
 			if player then
-				local pos = player:getpos()
+				local pos = player:get_pos()
 				local pname = player:get_player_name()
 				if hangglider.use[pname] then
 					local mrn_name = minetest.registered_nodes[minetest.get_node(vector.new(pos.x, pos.y-0.5, pos.z)).name]
@@ -220,7 +220,7 @@ minetest.register_entity("hangglider:glider", {
 							canExist = true
 
 							if not minetestd then
-								step_v = player:get_player_velocity().y
+								step_v = player:get_velocity().y
 								if step_v < 0 and step_v > -3 then
 									apply_physics_override(player, {speed=math.abs(step_v/2) + 0.75})
 								elseif step_v <= -3 then --Cap our gliding movement speed.
@@ -231,7 +231,7 @@ minetest.register_entity("hangglider:glider", {
 								if debug then player:hud_change(hangglider.debug[pname].id, "text", step_v..', '..player:get_physics_override().gravity..', '..tostring(hangglider.airbreak[pname])) end
 								apply_physics_override(player, {gravity=((step_v + 3)/20)})
 							end
-							--[[local vel = player:get_player_velocity()
+							--[[local vel = player:get_velocity()
 							if debug then player:hud_change(hangglider.debug[pname].id, "text", vel.y..', '..grav..', '..tostring(hangglider.airbreak[pname])) end
 
 							player:set_physics_override({gravity = (vel.y + 2.0)/20})
@@ -333,7 +333,7 @@ minetest.register_tool("hangglider:hangglider", {
 			minetest.sound_play("bedsheet", {pos=pos, max_hear_distance = 8, gain = 1.0})
 			if HUD_Overlay then player:hud_change(hangglider.id[pname], "text", "glider_struts.png") end
 			local airbreak = false
-			local vel = player:get_player_velocity().y
+			local vel = player:get_velocity().y
 			--[[if vel < -1.5 then  -- engage mid-air, falling fast, so stop but ramp velocity more quickly
 				--hangglider.airbreak[pname] = true
 				airbreak = true

--- a/mods/MODULES/hbhunger/hunger.lua
+++ b/mods/MODULES/hbhunger/hunger.lua
@@ -79,7 +79,7 @@ function hbhunger.item_eat(hunger_change, replace_with_item, poisen, heal, sound
 			if h == nil or hp == nil then
 				return
 			end
-			minetest.sound_play({name = sound or "hbhunger_eat_generic", gain = 1}, {pos=user:getpos(), max_hear_distance = 16})
+			minetest.sound_play({name = sound or "hbhunger_eat_generic", gain = 1}, {pos=user:get_pos(), max_hear_distance = 16})
 
 			-- Saturation
 			if h < 30 and hunger_change then
@@ -109,7 +109,7 @@ function hbhunger.item_eat(hunger_change, replace_with_item, poisen, heal, sound
 				if inv:room_for_item("main", replace_with_item) then
 					inv:add_item("main", replace_with_item)
 				else
-					minetest.add_item(user:getpos(), replace_with_item)
+					minetest.add_item(user:get_pos(), replace_with_item)
 				end
 			end
 		end

--- a/mods/MODULES/hopper/abms.lua
+++ b/mods/MODULES/hopper/abms.lua
@@ -21,7 +21,7 @@ minetest.register_abm({
 			and inv:room_for_item("main",
 				ItemStack(object:get_luaentity().itemstring)) then
 
-				posob = object:getpos()
+				posob = object:get_pos()
 
 				if math.abs(posob.x - pos.x) <= 0.5
 				and posob.y - pos.y <= 0.85

--- a/mods/MODULES/magic_mirror/init.lua
+++ b/mods/MODULES/magic_mirror/init.lua
@@ -52,7 +52,7 @@ minetest.register_tool("magic_mirror:magic_mirror", {
 
 			-- Get the player name, current position, and bed position.
 			local name = user:get_player_name()
-			local firstpos = user:getpos()
+			local firstpos = user:get_pos()
                         local rec_pos = beds.spawn[name]
 
 			-- Teleporting departure effect.
@@ -80,7 +80,7 @@ minetest.register_tool("magic_mirror:magic_mirror", {
                         end
 
                         -- Teleportation effects on arrival location.
-                        local nextpos = user:getpos()
+                        local nextpos = user:get_pos()
                         minetest.sound_play("magic_mirror_teleport", {pos = nextpos, gain = 1.0})
                         for i=1,50 do
                                 minetest.add_particle({
@@ -99,7 +99,7 @@ minetest.register_tool("magic_mirror:magic_mirror", {
 	
 		-- User does not have enough mana, play sound effect
 		else
-			local firstpos = user:getpos()
+			local firstpos = user:get_pos()
 			minetest.sound_play("bweapons_magic_pack_reload", {pos = firstpos, gain = 0.25})
 		end -- end of "mana_check false" section.
 end}) -- end register tool function

--- a/mods/MODULES/mobs_creatures/mobs/bogeyman.lua
+++ b/mods/MODULES/mobs_creatures/mobs/bogeyman.lua
@@ -52,7 +52,7 @@ mobs:register_mob("mobs_creatures:bogeyman", {
         },
 --particle spawner
    do_custom = function(self)
-   		local apos = self.object:getpos()
+   		local apos = self.object:get_pos()
 		minetest.add_particlespawner({
                         1, --amount
                         0.3, --time

--- a/mods/MODULES/mobs_creatures/mobs/boomer.lua
+++ b/mods/MODULES/mobs_creatures/mobs/boomer.lua
@@ -47,19 +47,19 @@ mobs:register_mob("mobs_creatures:boomer", {
 				item:add_wear(1000)
 				-- Tool break sound
 				if item:get_count() == 0 and wdef.sound and wdef.sound.breaks then
-					minetest.sound_play(wdef.sound.breaks, {pos = clicker:getpos(), gain = 0.5})
+					minetest.sound_play(wdef.sound.breaks, {pos = clicker:get_pos(), gain = 0.5})
 				end
 				clicker:set_wielded_item(item)
 			end
 			self._forced_explosion_countdown_timer = self.explosion_timer
-			minetest.sound_play(self.sounds.attack, {pos = self.object:getpos(), gain = 1, max_hear_distance = 16})
+			minetest.sound_play(self.sounds.attack, {pos = self.object:get_pos(), gain = 1, max_hear_distance = 16})
 		end
 	end,
 	do_custom = function(self, dtime)
 		if self._forced_explosion_countdown_timer ~= nil then
 			self._forced_explosion_countdown_timer = self._forced_explosion_countdown_timer - dtime
 			if self._forced_explosion_countdown_timer <= 0 then
-				mobs:explosion(self.object:getpos(), self.explosion_radius, 0, 1, self.sounds.explode)
+				mobs:explosion(self.object:get_pos(), self.explosion_radius, 0, 1, self.sounds.explode)
 				self.object:remove()
 			end
 		end

--- a/mods/MODULES/mobs_creatures/mobs/cacodemon.lua
+++ b/mods/MODULES/mobs_creatures/mobs/cacodemon.lua
@@ -69,7 +69,7 @@ mobs:register_arrow("mobs_creatures:a_cacodemon_plasma_ball", {
          full_punch_interval = 1.0,
          damage_groups = {fleshy = 25},
       }, nil)
-       minetest.sound_play({name = "mobs_creatures_common_shoot_plasmaball_hit", gain = 1.0}, {pos=player:getpos(), max_hear_distance = 12})
+       minetest.sound_play({name = "mobs_creatures_common_shoot_plasmaball_hit", gain = 1.0}, {pos=player:get_pos(), max_hear_distance = 12})
    end,
 
    hit_mob = function(self, player)

--- a/mods/MODULES/mobs_creatures/mobs/cave_floater.lua
+++ b/mods/MODULES/mobs_creatures/mobs/cave_floater.lua
@@ -74,8 +74,8 @@ mobs:register_arrow("mobs_creatures:a_cave_floater_gasball", {
          full_punch_interval = 1.0,
          damage_groups = {fleshy = 10},
       }, nil)
-       minetest.sound_play({name = "mobs_creatures_common_shoot_poisonball_hit", gain = 1.0}, {pos=player:getpos(), max_hear_distance = 12})
-       minetest.set_node(player:getpos(), {name = "mine_gas:gas"})
+       minetest.sound_play({name = "mobs_creatures_common_shoot_poisonball_hit", gain = 1.0}, {pos=player:get_pos(), max_hear_distance = 12})
+       minetest.set_node(player:get_pos(), {name = "mine_gas:gas"})
    end,
 
    hit_mob = function(self, player)

--- a/mods/MODULES/mobs_creatures/mobs/chicken.lua
+++ b/mods/MODULES/mobs_creatures/mobs/chicken.lua
@@ -62,7 +62,7 @@ mobs:register_mob("mobs_creatures:chicken", {
                         return
                 end
 
-                local pos = self.object:getpos()
+                local pos = self.object:get_pos()
 
                 minetest.add_item(pos, "mobs_creatures:egg")
 

--- a/mods/MODULES/mobs_creatures/mobs/cow.lua
+++ b/mods/MODULES/mobs_creatures/mobs/cow.lua
@@ -79,7 +79,7 @@ mobs:register_mob("mobs_creatures:cow", {
                         clicker:set_wielded_item(tool)
 		-- Add bucket of milk and play a sound effect
                         if inv:room_for_item("main", {name = "mobs_creatures:milk_bucket"}) then
-		                local pos = self.object:getpos()
+		                local pos = self.object:get_pos()
                                 clicker:get_inventory():add_item("main", "mobs_creatures:milk_bucket")
                                 minetest.sound_play("mobs_creatures_cow_milk", {
                                 pos = pos,

--- a/mods/MODULES/mobs_creatures/mobs/demon_eye.lua
+++ b/mods/MODULES/mobs_creatures/mobs/demon_eye.lua
@@ -44,7 +44,7 @@ mobs:register_mob("mobs_creatures:demon_eye", {
 	run_start = 0,		run_end = 40,
    },
    do_custom = function(self) -- Add downward particles of blood.
-                local apos = self.object:getpos()
+                local apos = self.object:get_pos()
                 minetest.add_particlespawner({
                        amount = 1.0, --amount
                        time = 1.0, --time

--- a/mods/MODULES/mobs_creatures/mobs/facehugger.lua
+++ b/mods/MODULES/mobs_creatures/mobs/facehugger.lua
@@ -45,7 +45,7 @@ mobs:register_mob("mobs_creatures:facehugger", {
       punch_end = 43,
    },
 --    do_custom = function(self)
---                 local pos = self.object:getpos()
+--                 local pos = self.object:get_pos()
 --                 local objs = minetest.get_objects_inside_radius(pos, 2)
 --                 for _, obj in pairs(objs) do
 --                         if obj:is_player() and obj:get_attach() == nil then

--- a/mods/MODULES/mobs_creatures/mobs/fire_imp.lua
+++ b/mods/MODULES/mobs_creatures/mobs/fire_imp.lua
@@ -65,7 +65,7 @@ mobs:register_mob("mobs_creatures:fire_imp", {
         },
         do_custom = function(self, dtime, nodef)
 	-- heats up water if it comes into contact with it and it evaporates.
-        local pos = self.object:getpos()
+        local pos = self.object:get_pos()
         if minetest.get_node(pos).name == "default:water_source" or minetest.get_node(pos).name == "default:water_flowing" or minetest.get_node(pos).name == "default:river_water_source" or minetest.get_node(pos).name == "default:river_water_flowing" or minetest.get_node(pos).name == "default:snow" or minetest.get_node(pos).name == "default:ice" then
                 minetest.add_particlespawner({
                         amount = 1,
@@ -111,7 +111,7 @@ mobs:register_arrow("mobs_creatures:fire_imp_fireball", {
          full_punch_interval = 1.0,
          damage_groups = {fleshy = 32},
       }, nil)
-       minetest.sound_play({name = "mobs_creatures_common_shoot_fireball_hit", gain = 1.0}, {pos=player:getpos(), max_hear_distance = 12})
+       minetest.sound_play({name = "mobs_creatures_common_shoot_fireball_hit", gain = 1.0}, {pos=player:get_pos(), max_hear_distance = 12})
    end,
 
    hit_mob = function(self, player)

--- a/mods/MODULES/mobs_creatures/mobs/fire_man.lua
+++ b/mods/MODULES/mobs_creatures/mobs/fire_man.lua
@@ -56,7 +56,7 @@ mobs:register_mob("mobs_creatures:fire_man", {
 --		{name = "mobs_creatures:ash", chance = 1, min = 1, max = 4}
 	},
    do_custom = function(self)
-		local apos = self.object:getpos()	
+		local apos = self.object:get_pos()
 		minetest.add_particlespawner({
 			1, --amount
 			0.3, --time
@@ -74,7 +74,7 @@ mobs:register_mob("mobs_creatures:fire_man", {
 			"fire_basic_flame.png" --texture
 		})
 		-- if standing in water, remove replace with air play steam.
-		local pos = self.object:getpos()	
+		local pos = self.object:get_pos()
                 if minetest.get_node(pos).name == "default:water_source" or minetest.get_node(pos).name == "default:water_flowing" or minetest.get_node(pos).name == "default:river_water_source" or minetest.get_node(pos).name == "default:river_water_flowing" or minetest.get_node(pos).name == "default:snow" or minetest.get_node(pos).name == "default:ice" then
 			minetest.add_particlespawner({
 				amount = 1,
@@ -133,7 +133,7 @@ mobs:register_arrow("mobs_creatures:fire_man_fireball", {
          full_punch_interval = 1.0,
          damage_groups = {fleshy = 32},
       }, nil)
-       minetest.sound_play({name = "mobs_creatures_common_shoot_fireball_hit", gain = 1.0}, {pos=player:getpos(), max_hear_distance = 12})
+       minetest.sound_play({name = "mobs_creatures_common_shoot_fireball_hit", gain = 1.0}, {pos=player:get_pos(), max_hear_distance = 12})
    end,
 
    hit_mob = function(self, player)

--- a/mods/MODULES/mobs_creatures/mobs/flying_saucer.lua
+++ b/mods/MODULES/mobs_creatures/mobs/flying_saucer.lua
@@ -68,7 +68,7 @@ mobs:register_arrow("mobs_creatures:a_devastator_energy_cannon", {
          full_punch_interval = 1.0,
          damage_groups = {fleshy = 100},
       }, nil)
-         minetest.sound_play({name = "mobs_creatures_common_shoot_plasmaball_hit", gain = 1.0}, {pos=player:getpos(), max_hear_distance = 16})
+         minetest.sound_play({name = "mobs_creatures_common_shoot_plasmaball_hit", gain = 1.0}, {pos=player:get_pos(), max_hear_distance = 16})
    end,
 
    hit_mob = function(self, player)

--- a/mods/MODULES/mobs_creatures/mobs/ghost.lua
+++ b/mods/MODULES/mobs_creatures/mobs/ghost.lua
@@ -55,7 +55,7 @@ mobs:register_mob('mobs_creatures:ghost', {
                 punch_end = 79,
         },
 	do_custom = function(self, pos)	-- ghosts will stay to haunt if there is no proper burial (gravestone) or if bones are still present.
-		local checkpos = self.object:getpos()
+		local checkpos = self.object:get_pos()
 		local gravecheck = minetest.find_node_near(checkpos, 8, {"group:gravestone"})
 		local bonecheck = minetest.find_node_near(checkpos, 8 ,{"mesecraft_bones:bones"})
 		if gravecheck == nil then				-- ghost stays to haunt

--- a/mods/MODULES/mobs_creatures/mobs/ghost_murderous.lua
+++ b/mods/MODULES/mobs_creatures/mobs/ghost_murderous.lua
@@ -55,7 +55,7 @@ mobs:register_mob("mobs_creatures:murderous_ghost", {
                 punch_end = 79,
         },
 	do_custom = function(self, pos)	-- ghosts will stay to haunt if there is no proper burial (gravestone) or if bones are still present.
-		local checkpos = self.object:getpos()
+		local checkpos = self.object:get_pos()
 		local gravecheck = minetest.find_node_near(checkpos, 8, {"group:gravestone"})
 		local bonecheck = minetest.find_node_near(checkpos, 8 ,{"mesecraft_bones:bones"})
 		if gravecheck == nil then				-- ghost stays to haunt

--- a/mods/MODULES/mobs_creatures/mobs/ghost_restless.lua
+++ b/mods/MODULES/mobs_creatures/mobs/ghost_restless.lua
@@ -55,7 +55,7 @@ mobs:register_mob('mobs_creatures:restless_ghost', {
                 punch_end = 79,
         },
 	do_custom = function(self, pos)	-- ghosts will stay to haunt if there is no proper burial (gravestone) or if bones are still present.
-		local checkpos = self.object:getpos()
+		local checkpos = self.object:get_pos()
 		local gravecheck = minetest.find_node_near(checkpos, 8, {"group:gravestone"})
 		local bonecheck = minetest.find_node_near(checkpos, 8 ,{"mesecraft_bones:bones"})
 		if gravecheck == nil then				-- ghost stays to haunt

--- a/mods/MODULES/mobs_creatures/mobs/giant_cave_spider.lua
+++ b/mods/MODULES/mobs_creatures/mobs/giant_cave_spider.lua
@@ -142,7 +142,7 @@ mobs:register_arrow("mobs_creatures:spiderweb_ball", {
     velocity = 12,
     -- direct hit
     hit_player = function(self, player)
-        local p = player:getpos()
+        local p = player:get_pos()
         explosion_web(p, "mobs_creatures:spiderweb")
     end,
     hit_mob = function(self, player)

--- a/mods/MODULES/mobs_creatures/mobs/grey_enlisted.lua
+++ b/mods/MODULES/mobs_creatures/mobs/grey_enlisted.lua
@@ -77,7 +77,7 @@ mobs:register_arrow("mobs_creatures:a_greys_energy_pistol", {
          full_punch_interval = 1.0,
          damage_groups = {fleshy = 20},
       }, nil)
-       minetest.sound_play({name = "mobs_creatures_common_shoot_plasmaball_hit", gain = 1.0}, {pos=player:getpos(), max_hear_distance = 12})
+       minetest.sound_play({name = "mobs_creatures_common_shoot_plasmaball_hit", gain = 1.0}, {pos=player:get_pos(), max_hear_distance = 12})
    end,
 
    hit_mob = function(self, player)

--- a/mods/MODULES/mobs_creatures/mobs/hellbaron.lua
+++ b/mods/MODULES/mobs_creatures/mobs/hellbaron.lua
@@ -70,7 +70,7 @@ mobs:register_arrow("mobs_creatures:a_hellbaron_plasmaball", {
          full_punch_interval = 1.0,
          damage_groups = {fleshy = 15},
       }, nil)
-       minetest.sound_play({name = "mobs_creatures_common_shoot_plasmaball_hit", gain = 1.0}, {pos=player:getpos(), max_hear_distance = 12})
+       minetest.sound_play({name = "mobs_creatures_common_shoot_plasmaball_hit", gain = 1.0}, {pos=player:get_pos(), max_hear_distance = 12})
    end,
    
    hit_mob = function(self, player)

--- a/mods/MODULES/mobs_creatures/mobs/imp.lua
+++ b/mods/MODULES/mobs_creatures/mobs/imp.lua
@@ -70,7 +70,7 @@ mobs:register_arrow("mobs_creatures:an_imp_fireball", {
          full_punch_interval = 1.0,
          damage_groups = {fleshy = 15},
       }, nil)
-       minetest.sound_play({name = "mobs_creatures_common_shoot_fireball_hit", gain = 1.0}, {pos=player:getpos(), max_hear_distance = 12})
+       minetest.sound_play({name = "mobs_creatures_common_shoot_fireball_hit", gain = 1.0}, {pos=player:get_pos(), max_hear_distance = 12})
    end,
 
    hit_mob = function(self, player)

--- a/mods/MODULES/mobs_creatures/mobs/magma_man.lua
+++ b/mods/MODULES/mobs_creatures/mobs/magma_man.lua
@@ -56,7 +56,7 @@ mobs:register_mob("mobs_creatures:magma_man", {
 	},
    do_custom = function(self)
 		-- if standing in water, remove replace with air play steam.
-		local pos = self.object:getpos()	
+		local pos = self.object:get_pos()
 		if minetest.get_node(pos).name == "default:water_source" or minetest.get_node(pos).name == "default:water_flowing" or minetest.get_node(pos).name == "default:river_water_source" or minetest.get_node(pos).name == "default:river_water_flowing" or minetest.get_node(pos).name == "default:snow" or minetest.get_node(pos).name == "default:ice" then
 			minetest.add_particlespawner({
 				amount = 1,

--- a/mods/MODULES/mobs_creatures/mobs/mooshroom.lua
+++ b/mods/MODULES/mobs_creatures/mobs/mooshroom.lua
@@ -47,7 +47,7 @@ mobs:register_mob("mobs_creatures:mooshroom", {
                 local item = clicker:get_wielded_item()
                 -- Use shears to get mushrooms and turn mooshroom into cow
                 if item:get_name() == "mobs:shears" then
-                        local pos = self.object:getpos()
+                        local pos = self.object:get_pos()
                         minetest.sound_play("shears", {pos = pos})
                         minetest.add_item({x=pos.x, y=pos.y+1.4, z=pos.z}, "flowers:mushroom_red" .. " 5")
 
@@ -62,7 +62,7 @@ mobs:register_mob("mobs_creatures:mooshroom", {
                         -- If room, add milk to inventory, otherwise drop as item
                         if inv:room_for_item("main", {name= "mobs_creatures:milk_bucket"}) then
                                 clicker:get_inventory():add_item("main", "mobs_creatures:milk_bucket")
-                                local pos = self.object:getpos()
+                                local pos = self.object:get_pos()
                                 minetest.sound_play("mobs_creatures_cow_milk", {
                                 pos = pos,
                                 gain = 1.0,
@@ -70,7 +70,7 @@ mobs:register_mob("mobs_creatures:mooshroom", {
                                 })
 
                         else
-                                local pos = self.object:getpos()
+                                local pos = self.object:get_pos()
                                 pos.y = pos.y + 0.5
                                 minetest.add_item(pos, {name = "mobs_creatures:milk_bucket"})
                                 minetest.sound_play("mobs_creatures_cow_milk", {
@@ -88,7 +88,7 @@ mobs:register_mob("mobs_creatures:mooshroom", {
                         if inv:room_for_item("main", {name="ethereal:hearty_stew"}) then
                                 clicker:get_inventory():add_item("main", "ethereal:hearty_stew")
                         else
-                                local pos = self.object:getpos()
+                                local pos = self.object:get_pos()
                                 pos.y = pos.y + 0.5
                                 minetest.add_item(pos, {name = "ethereal:hearty_stew"})
                         end

--- a/mods/MODULES/mobs_creatures/mobs/ocelot.lua
+++ b/mods/MODULES/mobs_creatures/mobs/ocelot.lua
@@ -73,7 +73,7 @@ local ocelot = {
 			-- 1/3 chance of getting tamed
 			if pr:next(1, 3) == 1 then
 				local yaw = self.object:get_yaw()
-				local cat = minetest.add_entity(self.object:getpos(), "mobs_creatures:cat")
+				local cat = minetest.add_entity(self.object:get_pos(), "mobs_creatures:cat")
 				cat:set_yaw(yaw)
 				local ent = cat:get_luaentity()
 				ent.owner = clicker:get_player_name()
@@ -115,13 +115,13 @@ cat.do_custom = function(dist, teleport_check_interval)
 		self._teleport_timer = self._teleport_timer - dtime
 		if self._teleport_timer <= 0 then
 			self._teleport_timer = teleport_check_interval
-			local mob_pos = self.object:getpos()
+			local mob_pos = self.object:get_pos()
 			local owner = minetest.get_player_by_name(self.owner)
 			if not owner then
 				-- No owner found, no teleportation
 				return
 			end
-			local owner_pos = owner:getpos()
+			local owner_pos = owner:get_pos()
 			local dist_from_owner = vector.distance(owner_pos, mob_pos)
 			if dist_from_owner > dist then
 				-- Check for nodes below air in a 5×1×5 area around the owner position
@@ -136,7 +136,7 @@ cat.do_custom = function(dist, teleport_check_interval)
 					if minetest.registered_nodes[minetest.get_node(telepos).name].walkable == false and
 							minetest.registered_nodes[minetest.get_node(telepos_below).name].walkable == true then
 						-- Correct position found! Let's teleport.
-						self.object:setpos(telepos)
+						self.object:set_pos(telepos)
 						return
 					end
 				end

--- a/mods/MODULES/mobs_creatures/mobs/sheep.lua
+++ b/mods/MODULES/mobs_creatures/mobs/sheep.lua
@@ -71,7 +71,7 @@ mobs:register_mob("mobs_creatures:sheep", {
 		if mobs:protect(self, clicker) then return end
 		if item:get_name() == "mobs:shears" and not self.gotten then
 			self.gotten = true
-			local pos = self.object:getpos()
+			local pos = self.object:get_pos()
 			minetest.sound_play("shears", {pos = pos})
 			pos.y = pos.y + 0.5
 			minetest.add_item(pos, ItemStack("wool:white "..math.random(1,3)))

--- a/mods/MODULES/mobs_creatures/mobs/skeleton_archer.lua
+++ b/mods/MODULES/mobs_creatures/mobs/skeleton_archer.lua
@@ -17,7 +17,7 @@ mobs:register_arrow("mobs_creatures:skeleton_archer_arrow", {
          full_punch_interval = 1.0,
          damage_groups = {fleshy = 10},
       }, nil)
-       minetest.sound_play({name = "mobs_creatures_common_shoot_arrow_hit", gain = 1.0}, {pos=player:getpos(), max_hear_distance = 12})
+       minetest.sound_play({name = "mobs_creatures_common_shoot_arrow_hit", gain = 1.0}, {pos=player:get_pos(), max_hear_distance = 12})
    end,
 
    hit_mob = function(self, player)

--- a/mods/MODULES/mobs_creatures/mobs/skull.lua
+++ b/mods/MODULES/mobs_creatures/mobs/skull.lua
@@ -31,7 +31,7 @@ mobs:register_mob("mobs_creatures:skull", {
    jump = true,
    fly = true,
    do_custom = function(self)
-		local apos = self.object:getpos()
+		local apos = self.object:get_pos()
                 part = minetest.add_particlespawner({
                         8, --amount
                         0.3, --time

--- a/mods/MODULES/mobs_creatures/mobs/snowman.lua
+++ b/mods/MODULES/mobs_creatures/mobs/snowman.lua
@@ -16,7 +16,7 @@ mobs:register_arrow("mobs_creatures:snowmans_snowball", {
 		 full_punch_interval = 1.0,
 		 damage_groups = {fleshy = 9},
 	      }, nil)
-	       minetest.sound_play({name = "default_snow_footstep", gain = 1.0}, {pos=player:getpos(), max_hear_distance = 8})
+	       minetest.sound_play({name = "default_snow_footstep", gain = 1.0}, {pos=player:get_pos(), max_hear_distance = 8})
 	   end,
 
 	   hit_mob = function(self, player)
@@ -108,7 +108,7 @@ mobs:register_mob("mobs_creatures:snowman", {
 		self._snowtimer = self._snowtimer + dtime
 		if self.health > 0 and self._snowtimer > snow_trail_frequency then
 			self._snowtimer = 0
-			local pos = self.object:getpos()
+			local pos = self.object:get_pos()
 			local below = {x=pos.x, y=pos.y-1, z=pos.z}
 			local def = minetest.registered_nodes[minetest.get_node(pos).name]
 			-- Node at snow golem's position must be replacable

--- a/mods/MODULES/mobs_creatures/mobs/wolf.lua
+++ b/mods/MODULES/mobs_creatures/mobs/wolf.lua
@@ -50,7 +50,7 @@ mobs:register_mob("mobs_creatures:wolf", {
 			-- 1/3 chance of getting tamed
 			if PseudoRandom(os.time()*10):next(1, 3) == 1 then
 				local yaw = self.object:get_yaw()
-				dog = minetest.add_entity(self.object:getpos(), "mobs_creatures:dog")
+				dog = minetest.add_entity(self.object:get_pos(), "mobs_creatures:dog")
 				dog:set_yaw(yaw)
 				ent = dog:get_luaentity()
 				ent.owner = clicker:get_player_name()
@@ -251,13 +251,13 @@ mobs:register_mob("mobs_creatures:dog", {
 		self._teleport_timer = self._teleport_timer - dtime
 		if self._teleport_timer <= 0 then
 			self._teleport_timer = teleport_check_interval
-			local mob_pos = self.object:getpos()
+			local mob_pos = self.object:get_pos()
 			local owner = minetest.get_player_by_name(self.owner)
 			if not owner then
 				-- No owner found, no teleportation
 				return
 			end
-			local owner_pos = owner:getpos()
+			local owner_pos = owner:get_pos()
 			local dist_from_owner = vector.distance(owner_pos, mob_pos)
 			if dist_from_owner > dist then
 				-- Check for nodes below air in a 5×1×5 area around the owner position
@@ -272,7 +272,7 @@ mobs:register_mob("mobs_creatures:dog", {
 					if minetest.registered_nodes[minetest.get_node(telepos).name].walkable == false and
 							minetest.registered_nodes[minetest.get_node(telepos_below).name].walkable == true then
 						-- Correct position found! Let's teleport.
-						self.object:setpos(telepos)
+						self.object:set_pos(telepos)
 						return
 					end
 				end

--- a/mods/MODULES/new_fireworks/init.lua
+++ b/mods/MODULES/new_fireworks/init.lua
@@ -129,7 +129,7 @@ end
 function rocket:on_activate(staticdata)
 	self.rdt = rdt
 	rdt = {}
-	minetest.sound_play("new_fireworks_rocket", {pos=self.object:getpos(),
+	minetest.sound_play("new_fireworks_rocket", {pos=self.object:get_pos(),
 											 max_hear_distance = 13,gain = 1,})
 	self.rocket_flytime = math.random(13,15)/10
 	self.object:setvelocity({x=0, y=9, z=0})
@@ -141,7 +141,7 @@ function rocket:on_step(dtime)
 	self.timer = self.timer + dtime
   self.rocket_firetime = self.rocket_firetime + dtime
   if self.rocket_firetime > 0.1 then
-    local pos = self.object:getpos()
+    local pos = self.object:get_pos()
     self.rocket_firetime = 0
     xrand = math.random(-15,15)/10
     zrand = math.random(-15,15)/10
@@ -160,12 +160,12 @@ function rocket:on_step(dtime)
   end
 	if self.timer > self.rocket_flytime then
 		if #self.rdt > 0 then
-			minetest.sound_play("new_fireworks_bang", {pos=self.object:getpos(),
+			minetest.sound_play("new_fireworks_bang", {pos=self.object:get_pos(),
 													 max_hear_distance = 90,gain = 3,})
 			for _,i in pairs(self.rdt) do
-				if i.figure == "ball" then partcl_gen(self.object:getpos(),ball_figure(0.1),4,4,i.color) end
-				if i.figure == "default" then partcl_gen(self.object:getpos(),default_figure(0.1),2,4,i.color) end
-				if i.figure == "custom" then partcl_gen(self.object:getpos(),custom_figure(i.form),7,7,i.color) end
+				if i.figure == "ball" then partcl_gen(self.object:get_pos(),ball_figure(0.1),4,4,i.color) end
+				if i.figure == "default" then partcl_gen(self.object:get_pos(),default_figure(0.1),2,4,i.color) end
+				if i.figure == "custom" then partcl_gen(self.object:get_pos(),custom_figure(i.form),7,7,i.color) end
 			end
 		end
 		self.object:remove()

--- a/mods/MODULES/orbs_of_time/init.lua
+++ b/mods/MODULES/orbs_of_time/init.lua
@@ -15,9 +15,9 @@ minetest.register_tool("orbs_of_time:orb_day", {
 	stack_max=1,
 	groups = { tool=1 },
 	on_use = function(itemstack, user)
-		minetest.sound_play("orbs_ding", {pos=user:getpos(), loop=false})
+		minetest.sound_play("orbs_ding", {pos=user:get_pos(), loop=false})
 		minetest.set_timeofday(0.5)
-		minetest.sound_play("orbs_birds", {pos=user:getpos(), loop=false})
+		minetest.sound_play("orbs_birds", {pos=user:get_pos(), loop=false})
 		if not minetest.settings:get_bool("creative_mode") then
 			itemstack:add_wear(65535/8)
 		end
@@ -35,9 +35,9 @@ minetest.register_tool("orbs_of_time:orb_night",{
 	stack_max=1,
 	groups = { tool=1 },
 	on_use = function(itemstack, user)
-		minetest.sound_play("orbs_ding", {pos=user:getpos(), loop=false})
+		minetest.sound_play("orbs_ding", {pos=user:get_pos(), loop=false})
 		minetest.set_timeofday(0)
-		minetest.sound_play("orbs_owl", {pos=user:getpos(), loop=false})
+		minetest.sound_play("orbs_owl", {pos=user:get_pos(), loop=false})
 		if not minetest.settings:get_bool("creative_mode") then
 			itemstack:add_wear(65535/8)
 		end
@@ -55,9 +55,9 @@ minetest.register_tool("orbs_of_time:orb_dawn", {
 	wield_image = "orbs_orb_day_weild.png^[lowpart:75:orbs_orb_night_weild.png",
 	stack_max=1,
 	on_use = function(itemstack, user)
-		minetest.sound_play("orbs_ding", {pos=user:getpos(), loop=false})
+		minetest.sound_play("orbs_ding", {pos=user:get_pos(), loop=false})
 		minetest.set_timeofday(0.2)
-		minetest.sound_play("orbs_birds", {pos=user:getpos(), loop=false})
+		minetest.sound_play("orbs_birds", {pos=user:get_pos(), loop=false})
 		if not minetest.settings:get_bool("creative_mode") then
 			itemstack:add_wear(65535/8)
 		end
@@ -74,9 +74,9 @@ minetest.register_tool("orbs_of_time:orb_dusk",{
 	wield_image = "orbs_orb_night_weild.png^[lowpart:75:orbs_orb_day_weild.png",
 	stack_max=1,
 	on_use = function(itemstack, user)
-		minetest.sound_play("orbs_ding", {pos=user:getpos(), loop=false})
+		minetest.sound_play("orbs_ding", {pos=user:get_pos(), loop=false})
 		minetest.set_timeofday(0.8)
-		minetest.sound_play("orbs_owl", {pos=user:getpos(), loop=false})
+		minetest.sound_play("orbs_owl", {pos=user:get_pos(), loop=false})
 		if not minetest.settings:get_bool("creative_mode") then
 			itemstack:add_wear(65535/8)
 		end

--- a/mods/MODULES/protector/doors_chest.lua
+++ b/mods/MODULES/protector/doors_chest.lua
@@ -77,7 +77,7 @@ function register_door(name, def)
 				minetest.get_meta(pt2):set_int("right", 1)
 			end
 
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				itemstack:take_item()
 			end
 			return itemstack

--- a/mods/MODULES/ropes/functions.lua
+++ b/mods/MODULES/ropes/functions.lua
@@ -88,7 +88,7 @@ ropes.move_players_down = function(pos, radius)
 	local _,obj
 	for _,obj in pairs(all_objects) do
 		if obj:is_player() then
-			local obj_pos = obj:getpos()
+			local obj_pos = obj:get_pos()
 			if math.abs(obj_pos.x-pos.x) < 0.5 and math.abs(obj_pos.z-pos.z) < 0.5 then
 				obj:moveto({x=obj_pos.x, y=obj_pos.y-1, z=obj_pos.z}, true)
 			end

--- a/mods/MODULES/thirsty/functions.lua
+++ b/mods/MODULES/thirsty/functions.lua
@@ -280,7 +280,7 @@ function thirsty.drink_handler(player, itemstack, node)
             --print("Filling a " .. item_name .. " to " .. thirsty.config.container_capacity[item_name])
             itemstack:set_wear(1) -- "looks full"
 	   -- Play a sound effect at the players position when filling container with water.
-           minetest.sound_play({name = "thirsty_fill_container", gain = 1.5}, {pos=player:getpos(), max_hear_distance = 8})
+           minetest.sound_play({name = "thirsty_fill_container", gain = 1.5}, {pos=player:get_pos(), max_hear_distance = 8})
         end
 
     elseif thirsty.config.container_capacity[item_name] then
@@ -293,7 +293,7 @@ function thirsty.drink_handler(player, itemstack, node)
                 local wear         = itemstack:get_wear()
                 local new_wear     = math.ceil(math.max(wear + wear_missing, 1))
 		-- play a drinking sound effect at the players position when they drink.
-	          minetest.sound_play({name = "thirsty_drink", gain = 1.5}, {pos=player:getpos(), max_hear_distance = 4})
+	          minetest.sound_play({name = "thirsty_drink", gain = 1.5}, {pos=player:get_pos(), max_hear_distance = 4})
                 if (new_wear > 65534) then
                     wear_missing = 65534 - wear
                     new_wear = 65534

--- a/mods/MODULES/tnt_revamped/functions.lua
+++ b/mods/MODULES/tnt_revamped/functions.lua
@@ -180,7 +180,7 @@ local function entity_physics(pos, radius, drops, in_water)
 
 		local damage = (4 / dist) * radius
 		if obj:is_player() then
-			local obj_vel = obj:get_player_velocity()
+			local obj_vel = obj:get_velocity()
 			obj:add_player_velocity(calc_velocity(pos, obj_pos,
 					obj_vel, radius * player_velocity_mul))
 

--- a/mods/MODULES/torch_bomb/init.lua
+++ b/mods/MODULES/torch_bomb/init.lua
@@ -635,9 +635,9 @@ if enable_grenade then
 			local player_pos = user:get_pos()
 			local obj = minetest.add_entity({x = player_pos.x, y = player_pos.y + 1.5, z = player_pos.z}, "torch_bomb:torch_grenade_entity")
 			local dir = user:get_look_dir()
-			obj:setvelocity(vector.multiply(dir, throw_velocity))
-			obj:setacceleration(gravity)
-			obj:setyaw(user:get_look_yaw()+math.pi)
+			obj:set_velocity(vector.multiply(dir, throw_velocity))
+			obj:set_acceleration(gravity)
+			obj:set_yaw(user:get_look_yaw()+math.pi)
 			local lua_entity = obj:get_luaentity()
 			lua_entity.player_name = user:get_player_name()
 			
@@ -648,7 +648,7 @@ if enable_grenade then
 				max_hear_distance = 32,
 			})
 			
-			if not minetest.setting_getbool("creative_mode") and not minetest.check_player_privs(user, "creative") then
+			if not minetest.settings:get_bool("creative_mode") and not minetest.check_player_privs(user, "creative") then
 				itemstack:set_count(itemstack:get_count() - 1)
 			end
 			

--- a/mods/MODULES/wielded_light/init.lua
+++ b/mods/MODULES/wielded_light/init.lua
@@ -107,13 +107,7 @@ end
 
 -- Get the projected position of an entity based on its velocity, rounded to the nearest block
 local function entity_pos(obj, offset)
-	local velocity
-	if (minetest.features.direct_velocity_on_players or not obj:is_player()) and obj.get_velocity then
-		velocity = obj:get_velocity()
-	else
-		velocity = obj:get_player_velocity()
-	end
-
+	local velocity = obj:get_velocity()
 	return wielded_light.get_light_position(
 		vector.round(
 			vector.add(


### PR DESCRIPTION
Removing these can reduce log file growth and reduce the work the server needs to do. It also helps prepare for Minetest 6 (or whatever) that removes these functions entirely.