### PR TITLE
fix pink flowers not appearing

### DIFF
--- a/mods/mesecraft_baked_clay/flowers.lua
+++ b/mods/mesecraft_baked_clay/flowers.lua
@@ -95,7 +95,7 @@ minetest.register_decoration({
 	},
 	y_min = 1,
 	y_max = 90,
-	decoration = "bakedmesecraft_baked_clayclay:lazarus",
+	decoration = "mesecraft_baked_clay:lazarus",
 	spawn_by = "default:jungletree",
 	num_spawn_by = 1
 })


### PR DESCRIPTION
Found this copy/paste error in the new baked clay update that will prevent the pink flowers from spawning as a decoration.