### PR TITLE
Fix replacements in crafting and guide

### DIFF
--- a/mods/MODULES/craftguide/init.lua
+++ b/mods/MODULES/craftguide/init.lua
@@ -733,7 +733,7 @@ local function get_desc(name)
 	      S("Unknown Item (@1)", name)))
 end
 
-local function get_tooltip(name, info)
+local function get_tooltip(name, info, recipe_type)
 	local tooltip
 
 	if info.groups then
@@ -770,9 +770,9 @@ local function get_tooltip(name, info)
 	if info.replace then
 		local desc = clr("#ff0", get_desc(info.replace))
 
-		if info.cooktime then
+		if info.cooktime and not recipe_type or recipe_type == "cooking" then
 			tooltip = add(S("Replaced by @1 on smelting", desc))
-		elseif info.burntime then
+		elseif info.burntime and not recipe_type or recipe_type == "fuel" then
 			tooltip = add(S("Replaced by @1 on burning", desc))
 		else
 			tooltip = add(S("Replaced by @1 on crafting", desc))
@@ -965,7 +965,7 @@ local function get_grid_fs(data, fs, rcp, spacing)
 		}
 
 		if next(infos) then
-			fs[#fs + 1] = get_tooltip(item, infos)
+			fs[#fs + 1] = get_tooltip(item, infos, rcp.type)
 		end
 	end
 

--- a/mods/MODULES/craftguide/init.lua
+++ b/mods/MODULES/craftguide/init.lua
@@ -719,12 +719,18 @@ local function get_desc(name)
 	if sub(name, 1, 1) == "_" then
 		name = sub(name, 2)
 	end
+	local prefix = ''
+	if string.find(name, ' ') then
+		item, count = name:match('([^ ]+) ([^ ]+)')
+		name = item
+		prefix = count..' '
+	end
 
 	local def = reg_items[name]
 
-	return def and (match(def.description, "%)([%w%s]*)") or def.description) or
+	return prefix..(def and (match(def.description, "%)([%w%s]*)") or def.description) or
 	      (def and match(name, ":.*"):gsub("%W%l", upper):sub(2):gsub("_", " ") or
-	      S("Unknown Item (@1)", name))
+	      S("Unknown Item (@1)", name)))
 end
 
 local function get_tooltip(name, info)

--- a/mods/MODULES/farming/mod.conf
+++ b/mods/MODULES/farming/mod.conf
@@ -1,6 +1,6 @@
 name = farming
 description = Adds many plants and food to Minetest.
 depends = default
-optional_depends = stairs, intllib, lucky_block, toolranks
+optional_depends = stairs, intllib, lucky_block, toolranks, craftguide
 author = TenPlus1
 title = Farming

--- a/mods/MODULES/magic_materials/crafts.lua
+++ b/mods/MODULES/magic_materials/crafts.lua
@@ -162,7 +162,7 @@ minetest.register_craft({
         {"mesecraft_bucket:bucket_lava", "magic_materials:enchanted_rune", "mesecraft_bucket:bucket_lava"},
         {"default:mese_crystal", "mesecraft_bucket:bucket_lava", "default:mese_crystal"},
     },
-    replacements = {{ "mesecraft_bucket:bucket_lava", "mesecraft_bucket:bucket_empty"}}
+    replacements = {{ "mesecraft_bucket:bucket_lava", "mesecraft_bucket:bucket_empty 4"}},
 })
 
 minetest.register_craft({

--- a/mods/MODULES/magic_materials/mod.conf
+++ b/mods/MODULES/magic_materials/mod.conf
@@ -1,6 +1,6 @@
 name = magic_materials
 description = A mod providing common resources and shared magic system for modpacks like gadgets_modpack, bweapons_modpack, and possibly others
 depends = default, mesecraft_bucket, farming
-optional_depends = technic, stairs
+optional_depends = technic, stairs, craftguide
 author = ClockGen
 title = Magic Materials


### PR DESCRIPTION
Recipes to watch for changes:
- Fire rune (now gives you 4 buckets back instead of just 1, and shows replacements in guide)
- Milk bucket (now displays that it gives 4 empty glasses back instead of "Unknown Item (vessels:glass 4)")
- Coffee cup (now shows replacements)
- Various other recipes from the farming mod with replacements