### PR TITLE
Loot for Geomoria, +2 random bugs that crash game load

### DIFF
--- a/minetest.conf
+++ b/minetest.conf
@@ -69,6 +69,9 @@ farming_stage_length=6000.0
 # font_api
 default_font=mozart
 
+# geomoria
+geomoria_lootchests_fix_buggy=false
+
 # hbarmor
 hbarmor_tick=1.0
 

--- a/mods/MODULES/drinks/drinks.lua
+++ b/mods/MODULES/drinks/drinks.lua
@@ -13,7 +13,7 @@ if minetest.get_modpath('thirsty') then
   do_drink = thirsty.drink
   drink_sound = drink_sound or 'thirsty_drink'
 end
-if minetest.get_modpath('hbhunger') then
+if minetest.get_modpath('hbhunger') and minetest.settings:get_bool("enable_damage") then   -- even if it's present, hbhunger doesn't load if damage is disabled
   do_add_settings = function(item, replace_with_item, juice_def)
     local factor = get_size_factor(replace_with_item)
     hbhunger.register_food(item, (juice_def.health or 1) * factor, replace_with_item, juice_def.poison and (juice_def.poison * factor), (juice_def.health or 0) * factor, juice_def.sound or drink_sound)

--- a/mods/MODULES/farming/crops/corn.lua
+++ b/mods/MODULES/farming/crops/corn.lua
@@ -1,7 +1,3 @@
-
---[[
-	Original textures
-
 local S = farming.intllib
 
 -- corn

--- a/mods/MODULES/geomoria_lootchests/fix_buggy.lua
+++ b/mods/MODULES/geomoria_lootchests/fix_buggy.lua
@@ -1,0 +1,41 @@
+--[[
+Without another mod (like this one) filling chests with loot, 
+Geomoria spawns default:chest without calling their constructor.
+This leaves buggy, useless chests instead of chests with loot.
+They can be detected as default:chest in a node lacking an associated
+inventory meta.
+]]
+
+
+if not minetest.settings:get_bool('geomoria_lootchests_fix_buggy' , false)
+	then return
+end
+
+-- find the lootchests lbm
+local lootchest_lbm
+for _, v in pairs(minetest.registered_lbms) do
+	if v.name == "geomoria_lootchests:chest".."_marker_replace"
+		then lootchest_lbm = v
+	end	
+end
+if not lootchest_lbm then
+	minetest.log("warning", 'geomoria_lootchests - Not fixing.  Cannot find Lootchest LBM ')
+	return
+end
+
+
+minetest.register_lbm({
+    name = "geomoria_lootchests:fix_buggy_chests",
+    label = "Fixing buggy chests",
+    nodenames = {"default:chest"},
+    action = function(pos, node)
+    	if not "default:chest" == minetest.get_node(pos).name then 
+    		return end
+    	if not minetest.get_inventory({type="node", pos=pos}) then
+    		-- Found one.  Nuke it.
+    		minetest.set_node(pos, {name="geomoria_lootchests:chest_marker"})
+    		lootchest_lbm.action(pos, "geomoria_lootchests:chest".."_marker")
+    		minetest.log("action", 'geomoria_lootchests - fixed '..tostring(pos))
+    	end
+	end
+})

--- a/mods/MODULES/geomoria_lootchests/init.lua
+++ b/mods/MODULES/geomoria_lootchests/init.lua
@@ -1,0 +1,157 @@
+geomoria_lootchests = {}
+
+local modname = "geomoria_lootchests"
+local modpath = minetest.get_modpath(modname)
+
+dofile(modpath .. "/item_table.lua")
+
+local chest_def = table.copy( minetest.registered_nodes["default:chest"] )
+chest_def.name = "geomoria_lootchests:chest"
+chest_def.description = "Loot Chest"
+chest_def.slot_spawn_chance = geomoria_lootchests.spawn_chance
+chest_def.slots = geomoria_lootchests.slots
+chest_def.spawn_in = {"default:diamondblock"}     --Spawn in which nodes, may be one itemstring or a list of them
+chest_def.spawn_on = {"default:diamondblock"}   --Spawn on which nodes, may be one itemstring or a list of them
+chest_def.spawn_in_rarity = 10000                                   --Spawn in rarity, approximate spacing between each node
+chest_def.spawn_on_rarity = 10000                                 --Spawn on rarity, spawns one out of defined value (if default is 1000 then on 1 out of 1000)
+
+    --Height limit
+chest_def.ymax = -130                                               --Max Y limit
+chest_def.ymin = -180                                             --Min Y limit
+
+lootchests.register_lootchest(chest_def)
+
+function geomoria_mod.treasure_chest_hook(pos, min_x, max_x, min_z, max_z, data, area, node)
+--  return node[treasure_chest]
+	return minetest.get_content_id("geomoria_lootchests:chest_marker")
+end
+
+--[[
+{
+    --Spawning
+}
+--]]
+
+
+
+--[[ Geomoria, as designed, leaves behind a mess of buggy loot chests.
+The chests are created, along with everything else, using voxelmanip
+They never have their constructors run, and so they never initialize 
+the node inventory.  They present as a broken formspec, a great big grey
+rectangle where inventory slots should be.
+
+On servers that have been up for a while, it's not enough to just
+create new loot chests when new tunnels are generated.  The old, 
+buggy, left behind default:chest should also be replaced with lootchests.
+--]]
+
+if minetest.settings:get("mesecraft_geomoria_loot_fix_buggy") then
+	local no_op = nil -- todo: actually work on this feature
+end
+
+
+
+
+
+minetest.register_chatcommand("test", {
+    params = "",
+    -- Short parameter description.  See the below note.
+
+    description = "",
+    -- General description of the command's purpose.
+
+    privs = {},
+    -- Required privileges to run. See `minetest.check_player_privs()` for
+    -- the format and see [Privileges] for an overview of privileges.
+
+    func = function(name, param)
+		minetest.chat_send_player("singleplayer", tostring(minetest.registered_nodes["geomoria_lootchests:chest_marker"]))
+	end,
+    -- Called when command is run.
+    -- * `name` is the name of the player who issued the command.
+    -- * `param` is a string with the full arguments to the command.
+    -- Returns a boolean for success and a string value.
+    -- The string is shown to the issuing player upon exit of `func` or,
+    -- if `func` returns `false` and no string, the help message is shown.
+})
+
+
+
+
+
+
+
+
+------------		Debugging Code
+--[[
+
+local function roundPos(pos)
+	-- Note that y is typically at 0.5, and may arbitrarily round up or down given a chance
+	-- adding an extra 0.01 to y to goose it up instead of down
+	local rval = {}
+	rval.x = math.floor(pos.x+0.5)
+	rval.y = math.floor(pos.y+0.51)
+	rval.z = math.floor(pos.z+0.5)
+	return rval
+	end
+
+local hash = minetest.hash_node_position
+--local unhash = minetest.get_position_from_hash
+local chestlog = {}
+local hashlist = {}
+
+minetest.register_abm({
+    label = "Teleporting to Geomoria chests",
+    nodenames = {"geomoria_lootchests:chest"},
+    interval = 3,
+    chance = 1,
+
+    action = function(pos, node, active_object_count, active_object_count_wider)
+    if "geomoria_lootchests:chest" ~= minetest.get_node(pos).name then return end
+
+	local player = minetest.get_player_by_name("singleplayer")
+	if not player then return end
+
+	if #chestlog == 0 then
+    	local ppos = vector.new(pos)
+    	ppos.y = ppos.y+0.6
+    	player:set_pos(ppos)
+    end
+
+    local h = hash(pos)
+    if not hashlist[h] then
+    	hashlist[h] = true
+    	table.insert(chestlog, vector.new(pos))
+    end
+
+    if not "geomoria_lootchests:chest" == minetest.get_node(chestlog[1]).name
+    then
+    	table.remove(chestlog,1)
+    	if #chestlog == 0 then return end
+    	local ppos = vector.new(chestlog[1])
+    	ppos.y = ppos.y+0.6
+    	player:set_pos(ppos)
+    end
+
+
+	local direct = player:get_look_dir()
+	direct = roundPos({x=direct.x*10, y=direct.y*10, z=direct.z*10})
+	local playerpos = player:get_pos()
+	if not playerpos then return end
+	local spos = vector.subtract(pos,roundPos(playerpos))
+	end
+})
+
+
+-- dump a table of registered items
+-- dump is incomplete, only includes mods loaded before this one
+-- bash$ sort < regitems.txt > regitems.sorted.txt
+
+local regitems = {}
+for k,_ in pairs(minetest.registered_items) do
+	table.insert(regitems, k)
+end
+minetest.safe_file_write(modpath..'/regitems.txt', table.concat(regitems,'\n') )
+
+
+--]]

--- a/mods/MODULES/geomoria_lootchests/init.lua
+++ b/mods/MODULES/geomoria_lootchests/init.lua
@@ -10,78 +10,26 @@ chest_def.name = "geomoria_lootchests:chest"
 chest_def.description = "Loot Chest"
 chest_def.slot_spawn_chance = geomoria_lootchests.spawn_chance
 chest_def.slots = geomoria_lootchests.slots
-chest_def.spawn_in = {"default:diamondblock"}     --Spawn in which nodes, may be one itemstring or a list of them
-chest_def.spawn_on = {"default:diamondblock"}   --Spawn on which nodes, may be one itemstring or a list of them
-chest_def.spawn_in_rarity = 10000                                   --Spawn in rarity, approximate spacing between each node
-chest_def.spawn_on_rarity = 10000                                 --Spawn on rarity, spawns one out of defined value (if default is 1000 then on 1 out of 1000)
-
-    --Height limit
+chest_def.spawn_in = {"default:diamondblock"}     --Prevent Lootchest mod from spawning these randomly.
+chest_def.spawn_on = {"default:diamondblock"}     --We only want them where geomoria puts them.
+chest_def.spawn_in_rarity = 1000000
+chest_def.spawn_on_rarity = 1000000
 chest_def.ymax = -130                                               --Max Y limit
 chest_def.ymin = -180                                             --Min Y limit
 
 lootchests.register_lootchest(chest_def)
 
+-- Use the hook supplied by geomoria for this purpose
 function geomoria_mod.treasure_chest_hook(pos, min_x, max_x, min_z, max_z, data, area, node)
---  return node[treasure_chest]
 	return minetest.get_content_id("geomoria_lootchests:chest_marker")
 end
 
---[[
-{
-    --Spawning
-}
---]]
+
+-- optional.  see setting: geomoria_lootchests_fix_buggy 
+dofile(modpath .. "/fix_buggy.lua")
 
 
-
---[[ Geomoria, as designed, leaves behind a mess of buggy loot chests.
-The chests are created, along with everything else, using voxelmanip
-They never have their constructors run, and so they never initialize 
-the node inventory.  They present as a broken formspec, a great big grey
-rectangle where inventory slots should be.
-
-On servers that have been up for a while, it's not enough to just
-create new loot chests when new tunnels are generated.  The old, 
-buggy, left behind default:chest should also be replaced with lootchests.
---]]
-
-if minetest.settings:get("mesecraft_geomoria_loot_fix_buggy") then
-	local no_op = nil -- todo: actually work on this feature
-end
-
-
-
-
-
-minetest.register_chatcommand("test", {
-    params = "",
-    -- Short parameter description.  See the below note.
-
-    description = "",
-    -- General description of the command's purpose.
-
-    privs = {},
-    -- Required privileges to run. See `minetest.check_player_privs()` for
-    -- the format and see [Privileges] for an overview of privileges.
-
-    func = function(name, param)
-		minetest.chat_send_player("singleplayer", tostring(minetest.registered_nodes["geomoria_lootchests:chest_marker"]))
-	end,
-    -- Called when command is run.
-    -- * `name` is the name of the player who issued the command.
-    -- * `param` is a string with the full arguments to the command.
-    -- Returns a boolean for success and a string value.
-    -- The string is shown to the issuing player upon exit of `func` or,
-    -- if `func` returns `false` and no string, the help message is shown.
-})
-
-
-
-
-
-
-
-
+------------        EOF
 ------------		Debugging Code
 --[[
 

--- a/mods/MODULES/geomoria_lootchests/item_table.lua
+++ b/mods/MODULES/geomoria_lootchests/item_table.lua
@@ -81,42 +81,13 @@ loot_table = {
 
 
 
-
---[[
-
-    {""},
-
-
-
-
-
---]]
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 ----  End Configuration Section
 
 local log = function(msg)
     minetest.log('warning','geomoria_lootchests - '..msg)
-    if minetest.get_player_by_name('singleplayer') then 
-        minetest.chat_send_player("singleplayer", tostring(msg) )
-    end
+--    if minetest.get_player_by_name('singleplayer') then 
+--        minetest.chat_send_player("singleplayer", tostring(msg) )
+--    end
 end
 
 -- remove stuff if the relevant mod isn't loaded

--- a/mods/MODULES/geomoria_lootchests/item_table.lua
+++ b/mods/MODULES/geomoria_lootchests/item_table.lua
@@ -1,0 +1,132 @@
+
+-- settings related to lootchests mod
+geomoria_lootchests.slots = 32          -- capacity of the chest, number of item slots
+geomoria_lootchests.spawn_chance = 50   -- how likely, in percent, a given slot has stuff; 
+                                        -- in other words: how full is the chest likely to be?
+
+
+-- the number is the maximum number that might spawn per slot
+-- a smaller number might spawn, or the item might spawn in more than one slot
+-- Note that there's a sanity test later to remove anything not loaded, typos won't crash
+loot_table = {
+    {"default:coal_lump", 40},
+    {"default:stick", 99},
+    {"default:torch", 90},
+    {"candles:candle", 5},
+    {"pigiron:iron_ingot", 12},
+    {"default:steel_ingot", 8},
+    {"default:copper_ingot", 16},
+    {"default:tin_ingot", 16},
+    {"default:bronze_ingot", 14},
+    {"moreores:silver_ingot", 6},
+    {"default:gold_ingot", 2},
+    {"default:mese_post_light", 2},
+    {"df_trees:goblin_cap_wood_mese_light", 2},
+    {"moreblocks:glow_glass", 1},
+    {"death_compass:inactive", 2},
+    {"bees:grafting_tool"},
+    {"bees:bottle_honey", 1},
+    {"bees:wax", 10},
+    {"farming:seed_barley", 10},
+    {"farming:seed_cotton", 10},
+    {"farming:seed_mint", 10},
+    {"farming:seed_oat", 10},
+    {"farming:seed_rice", 10},
+    {"farming:seed_rye", 10},
+    {"farming:seed_wheat", 10},
+    {"farming:string", 6},
+    {"fire:flint_and_steel"},
+    {"bweapons_utility_pack:torch_bow"},
+    {"bweapons_bows_pack:arrow", 50},
+    {"bweapons_bows_pack:bolt", 50},
+    {"bweapons_bows_pack:crossbow"},
+    {"bweapons_bows_pack:wooden_bow"},
+    {"default:axe_bronze"},
+    {"default:axe_steel"},
+    {"default:pick_bronze"},
+    {"default:pick_steel"},
+    {"default:shovel_bronze"},
+    {"default:shovel_steel"},
+    {"default:sword_bronze"},
+    {"default:sword_steel"},
+    {"farming:hoe_bronze"},
+    {"farming:hoe_steel"},
+    {"moreores:axe_silver"},
+    {"moreores:hoe_silver"},
+    {"moreores:pick_silver"},
+    {"moreores:shovel_silver"},
+    {"moreores:sword_silver"},
+    {"3d_armor:boots_bronze"},
+    {"3d_armor:boots_steel"},
+    {"3d_armor:chestplate_bronze"},
+    {"3d_armor:chestplate_steel"},
+    {"3d_armor:helmet_bronze"},
+    {"3d_armor:helmet_steel"},
+    {"3d_armor:leggings_bronze"},
+    {"3d_armor:leggings_steel"},
+    {"mobs:horseshoe_bronze"},
+    {"mobs:horseshoe_steel"},
+    {"mobs:lasso"},
+    {"mobs:shears"},
+    {"shields:shield_bronze"},
+    {"shields:shield_steel"},
+    {"realcompass:0"},
+    {"ropes:wood1rope_block", 2},
+    {"tnt:gunpowder", 10},
+    {"vessels:glass_bottle", 3},
+    {"vessels:glass_fragments", 20},
+    {"thirsty:gold_canteen"},
+    {"thirsty:silver_canteen"},
+}
+
+
+
+
+--[[
+
+    {""},
+
+
+
+
+
+--]]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+----  End Configuration Section
+
+local log = function(msg)
+    minetest.log('warning','geomoria_lootchests - '..msg)
+    if minetest.get_player_by_name('singleplayer') then 
+        minetest.chat_send_player("singleplayer", tostring(msg) )
+    end
+end
+
+-- remove stuff if the relevant mod isn't loaded
+for k, v in pairs(table.copy(loot_table)) do
+    if not minetest.registered_items[v[1]] then
+        log(v[1]..' not loaded, removing from loot table')
+--        log('tested '..tostring( minetest.registered_nodes[v[1]]) )
+        table.remove(loot_table, k)
+    end
+end
+
+-- commit final table
+lootchests.loot_table["geomoria_lootchests:chest"] = loot_table

--- a/mods/MODULES/geomoria_lootchests/mod.conf
+++ b/mods/MODULES/geomoria_lootchests/mod.conf
@@ -1,0 +1,7 @@
+name = geomoria_lootchests
+description = Adds lootchests to Geomoria, designed for MeseCraft
+depends = default, geomoria, lootchests
+optional_depends = pigiron, df_trees, df_farming, moreblocks, death_compass, candles, moreores, bees, farming, fire, bweapons_utility_pack, mobs, shields, realcompass, tnt, ropes, tnt, vessels, thirsty
+
+author = gd2shoe
+title = Geomoria Loot

--- a/mods/MODULES/geomoria_lootchests/readme.md
+++ b/mods/MODULES/geomoria_lootchests/readme.md
@@ -1,0 +1,11 @@
+Add lootchests to Geomoria
+
+This mod integrates Geomoria and Lootchests, providing treasure in long forgotten corridors.
+
+Optionally, it provides a fix for broken chests left behind by prior versions of Geomoria. (not implemented yet)
+
+This mod was designed for MeseCraft.  If someone wants to fork it as a stand-alone mod, it should be very simple to edit item_table.lua and mod.conf
+
+Changelog:
+
+- 0.1 - Initial upload

--- a/mods/MODULES/geomoria_lootchests/readme.md
+++ b/mods/MODULES/geomoria_lootchests/readme.md
@@ -2,10 +2,11 @@ Add lootchests to Geomoria
 
 This mod integrates Geomoria and Lootchests, providing treasure in long forgotten corridors.
 
-Optionally, it provides a fix for broken chests left behind by prior versions of Geomoria. (not implemented yet)
+Optionally, it provides a fix for broken chests left behind by Geomoria when loading a mapblock. Please note that this will replace ALL default:chest which lack an associated inventory.  Empty chests are fine (they have an inventory, just empty).
 
 This mod was designed for MeseCraft.  If someone wants to fork it as a stand-alone mod, it should be very simple to edit item_table.lua and mod.conf
 
 Changelog:
 
 - 0.1 - Initial upload
+- 0.2 - Cleanup and added an option to fix buggy chests

--- a/mods/MODULES/geomoria_lootchests/settingtypes.txt
+++ b/mods/MODULES/geomoria_lootchests/settingtypes.txt
@@ -1,0 +1,7 @@
+#	Replace buggy default:chest left behind by Geomoria
+#	Use this on servers when updating to populate chests that lack an inventory
+#	(not chests with an empty inventory, buggy ones that have none at all)
+#	Runs every 10 seconds as an ABM
+#mesecraft_geomoria_loot_fix_buggy (Fills buggy chests with loot) bool true
+
+# not implemented yet -- todo...

--- a/mods/MODULES/geomoria_lootchests/settingtypes.txt
+++ b/mods/MODULES/geomoria_lootchests/settingtypes.txt
@@ -1,7 +1,6 @@
 #	Replace buggy default:chest left behind by Geomoria
 #	Use this on servers when updating to populate chests that lack an inventory
 #	(not chests with an empty inventory, buggy ones that have none at all)
-#	Runs every 10 seconds as an ABM
-#mesecraft_geomoria_loot_fix_buggy (Fills buggy chests with loot) bool true
+#	Runs as an LBM when mapblocks are loaded
 
-# not implemented yet -- todo...
+geomoria_lootchests_fix_buggy (Fills buggy chests with loot) bool false

--- a/mods/MODULES/trash_can/init.lua
+++ b/mods/MODULES/trash_can/init.lua
@@ -64,7 +64,8 @@ minetest.register_node("trash_can:trash_can_wooden",{
 			"size[8,9]" ..
 			"button[0,0;2,1;empty;Empty Trash]" ..
 			"list[context;trashlist;3,1;2,3;]" ..
-			"list[current_player;main;0,5;8,4;]"
+			"list[current_player;main;0,5;8,4;]" ..
+			"listring[]"
 		)
 		meta:set_string("infotext", "Trash Can")
 		local inv = meta:get_inventory()
@@ -112,4 +113,18 @@ minetest.register_craft({
 		{'group:wood', '', 'group:wood'},
 		{'group:wood', 'group:wood', 'group:wood'},
 	}
+})
+
+
+-- Update legacy cans
+minetest.register_lbm({
+    label = "update legacy cans",
+    name = "trash_can:update_legacy",
+    nodenames = {"trash_can:trash_can_wooden"},
+    run_at_every_load = true,
+    action = function(pos)
+    	if not "trash_can:trash_can_wooden" == minetest.get_node(pos).name
+    		then return end
+    	minetest.registered_nodes["trash_can:trash_can_wooden"].on_construct(pos)
+	end
 })


### PR DESCRIPTION
Fixed trivial bugs in farming, drinks
Fixed nuisance in geomoria (more remains)

Added brand new mod that integrates Lootchests into Geomoria.  Geomoria is now worth exploring. (apx y=-170 )
I don't claim to have the loot properly balanced, but I made it very, very easy to adjust the payout (item_table.lua)

Added shift-click capability to trash can.  This makes them much friendlier to use.  Alternatively, trash can could be updated to https://github.com/minetest-mods/trash_can version 0.2.3 (current), which has this feature.  (but lacks the LBM to fix legacy cans)