### PR TITLE
Fixed unintended S() related dependencies

### DIFF
--- a/mods/MODULES/bell/init.lua
+++ b/mods/MODULES/bell/init.lua
@@ -1,4 +1,4 @@
-S = minetest.get_translator("bell")
+local S = minetest.get_translator("bell")
 
 -- bell_positions are saved through server restart
 -- bells ring every hour

--- a/mods/mesecraft_baked_clay/flowers.lua
+++ b/mods/mesecraft_baked_clay/flowers.lua
@@ -1,5 +1,5 @@
 -- 5.x translation
-S = minetest.get_translator("mesecraft_baked_clay")
+local S = minetest.get_translator("mesecraft_baked_clay")
 
 local flowers = {
 	{"delphinium", "Blue Delphinium",

--- a/mods/mesecraft_baked_clay/init.lua
+++ b/mods/mesecraft_baked_clay/init.lua
@@ -1,5 +1,5 @@
 -- 5.x translation
-S = minetest.get_translator("mesecraft_baked_clay")
+local S = minetest.get_translator("mesecraft_baked_clay")
 
 -- list of clay colours
 local clay = {

--- a/mods/mesecraft_mobs/init.lua
+++ b/mods/mesecraft_mobs/init.lua
@@ -1,6 +1,7 @@
 -- TODO: ADD GLOBAL VARIABLES FOR CONTROLLING HEIGHT SPAWNS VIA MINETEST SETTING OR MINETEST.CONF
 
 local path = minetest.get_modpath("mesecraft_mobs")
+S = minetest.get_translator("mesecraft_mobs")
 
 --staging area for new mobs that are incomplete
 dofile(path .. "/mobs/facehugger.lua")


### PR DESCRIPTION
See https://github.com/MeseCraft/MeseCraft/issues/82

Mods shouldn't be creating a global S(), and mods shouldn't assume the existence of S().  S() needs to be initialized with the correct translation domain.

See: https://minetest.gitlab.io/minetest/translations/

> It is intended to be used in the following way, ...:
> local S = minetest.get_translator(textdomain)
> S(str, ...)
> ...
> It is advised to use the name of the mod as textdomain whenever possible...

