### PR TITLE
Migrate items from old voidchest namespace

### DIFF
--- a/mods/mesecraft_void_chest/init.lua
+++ b/mods/mesecraft_void_chest/init.lua
@@ -106,5 +106,16 @@ end
 minetest.register_on_joinplayer(function(player)
 	local inv = player:get_inventory()
 	inv:set_size("mesecraft_void_chest:void_chest", 8*4)
+
+	--migrate from void_chest:void_chest to mesecraft_void_chest:void_chest
+	local vcCount = inv:get_size('void_chest:void_chest') -- should be 8*4 or 0
+	local stack
+	if vcCount and vcCount>1 then
+		for i = 1,vcCount do
+			stack = inv:get_stack('void_chest:void_chest', i)
+			stack = inv:add_item('mesecraft_void_chest:void_chest', stack) -- function returns items that couldn't be added
+			inv:set_stack('void_chest:void_chest', i, stack)
+		end
+	end
 end)
 


### PR DESCRIPTION
REJECT THIS PR if the merge of unstable into stable was a mistake, and other corrective measures are being taken.  #90 

Consider this PR if the merge was deliberate.  Yes, this IS a PR directly into master.  This moves items from the old voidchest namespace into the new one, saving players' items.  You'll smooth over some hurt feelings with this.  This does not return voidchests that were erased by cleaner, it just shuffles the inventory to where the formspec expects items to be.  When this is over, you can expect me to submit this same PR to unstable.

(Yes, tested, but not extensively so.  I've also tested it with the names reversed in case a rollback is incomplete.)