### PR TITLE
Replace deprecated `set_physics_override()` calls

### DIFF
--- a/mods/MODULES/playereffects/examples.lua
+++ b/mods/MODULES/playereffects/examples.lua
@@ -42,22 +42,22 @@ playereffects.register_effect_type("blind", "Blind", nil, {},
 -- Makes the user faster
 playereffects.register_effect_type("high_speed", "High speed", nil, {"speed"}, 
 	function(player)
-		player:set_physics_override(4,nil,nil)
+		player:set_physics_override({speed = 4})
 	end,
 	
 	function(effect, player)
-		player:set_physics_override(1,nil,nil)
+		player:set_physics_override({speed = 1})
 	end
 )
 
 -- Makes the user faster (hidden effect)
 playereffects.register_effect_type("high_speed_hidden", "High speed", nil, {"speed"}, 
 	function(player)
-		player:set_physics_override(4,nil,nil)
+		player:set_physics_override({speed = 4})
 	end,
 	
 	function(effect, player)
-		player:set_physics_override(1,nil,nil)
+		player:set_physics_override({speed = 1})
 	end,
 	true
 )
@@ -67,21 +67,21 @@ playereffects.register_effect_type("high_speed_hidden", "High speed", nil, {"spe
 -- Slows the user down
 playereffects.register_effect_type("low_speed", "Low speed", nil, {"speed"}, 
 	function(player)
-		player:set_physics_override(0.25,nil,nil)
+		player:set_physics_override({speed = 0.25})
 	end,
 	
 	function(effect, player)
-		player:set_physics_override(1,nil,nil)
+		player:set_physics_override({speed = 1})
 	end
 )
 
 -- Increases the jump height
 playereffects.register_effect_type("highjump", "Greater jump height", "playereffects_example_highjump.png", {"jump"},
 	function(player)
-		player:set_physics_override(nil,2,nil)
+		player:set_physics_override({jump = 2})
 	end,
 	function(effect, player)
-		player:set_physics_override(nil,1,nil)
+		player:set_physics_override({jump = 1})
 	end
 )
 

--- a/mods/MODULES/playerplus/init.lua
+++ b/mods/MODULES/playerplus/init.lua
@@ -146,7 +146,7 @@ minetest.register_globalstep(function(dtime)
 
 		-- set player physics
 		if not monoids and not pova_mod then
-			player:set_physics_override(def.speed, def.jump, def.gravity)
+			player:set_physics_override(def)
 		end
 --[[
 		print ("Speed: " .. def.speed

--- a/mods/mesecraft_beds/functions.lua
+++ b/mods/mesecraft_beds/functions.lua
@@ -75,7 +75,7 @@ local function lay_down(player, pos, bed_pos, state, skip)
 		player:set_eye_offset({x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 0})
 		player:set_look_horizontal(math.random(1, 180) / 100)
 		player_api.player_attached[name] = false
-		player:set_physics_override(1, 1, 1)
+		player:set_physics_override({speed = 1, jump = 1, gravity = 1})
 		hud_flags.wielditem = true
 		player_api.set_animation(player, "stand" , 30)
 
@@ -97,7 +97,7 @@ local function lay_down(player, pos, bed_pos, state, skip)
 			y = bed_pos.y + 0.07,
 			z = bed_pos.z + dir.z / 2
 		}
-		player:set_physics_override(0, 0, 0)
+		player:set_physics_override({speed = 0, jump = 0, gravity = 0})
 		player:set_pos(p)
 		player_api.player_attached[name] = true
 		hud_flags.wielditem = false


### PR DESCRIPTION
Calling `set_physics_override(num, num; num)` doesn't work anymore on 5.9.0 or higher.
Fixes a crash reported by a user on the mesecons bugtracker https://github.com/minetest-mods/mesecons/issues/687