### PR TITLE
Update calls to deprecated functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 MeseCraft - A blocky survival game.
 ==========================
 Copyright (C) 2019-2023 MeseCraft
-www.mesecraft.com
 <contact@mesecraft.com>
 
 
 Description
 -------------------------
-The best game for Minetest. A survival game with new depth, mechanics, biomes, mobs and many essential additions. Has a focus on being fun, user-friendly, stable, and minimalist but featured. Join our cause: https://www.mesecraft.com
+The best game for Minetest. A survival game with new depth, mechanics, biomes, mobs and many essential additions. Has a focus on being fun, user-friendly, stable, and minimalist but featured. Join us at: https://www.mesecraft.com
 
 Currently, this game is stable and has been debugged on an online server environment with many players. There is active development so new bugs may come and go.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Credits and Acknowledgements
 -------------------------
 Designed by Jeremy Weston and MeseCraft community contributors.
 
-Thank you to the Minetest community.
+A special thanks to the Minetest community.
 
 License
 --------------------------

--- a/mods/MODULES/dfcaverns/df_dependencies/mod.conf
+++ b/mods/MODULES/dfcaverns/df_dependencies/mod.conf
@@ -2,4 +2,4 @@ name = df_dependencies
 description = A utility mod for df_caverns that gathers all dependencies on minetest_game in one place, to ease cross-compatibility efforts with Minetest Game, MineClone2 and MineClone5.
 depends =
 optional_depends = mesecraft_beds, mesecraft_bucket, default, doors, farming, fireflies, mcl_beds, mcl_buckets, mcl_chests, mcl_compatibility, mcl_copper, mcl_core, mcl_doors, mcl_explosions, mcl_farming, mcl_fences, mcl_formspec, mcl_furnaces, mcl_init, mcl_mapgen, mcl_maps, mcl_mobitems, mcl_ocean, mcl_potions, mcl_sounds, mcl_stairs, mcl_strongholds, mcl_tnt, mcl_torches, mcl_wool, mcl_worlds, mclx_core, mesecons, moreblocks, stairs, tnt, vessels, wool
-supported_games = minetest_game, MineClone2
+supported_games = minetest_game, mineclone2

--- a/mods/MODULES/playereffects/examples.lua
+++ b/mods/MODULES/playereffects/examples.lua
@@ -42,22 +42,22 @@ playereffects.register_effect_type("blind", "Blind", nil, {},
 -- Makes the user faster
 playereffects.register_effect_type("high_speed", "High speed", nil, {"speed"}, 
 	function(player)
-		player:set_physics_override(4,nil,nil)
+		player:set_physics_override({speed = 4})
 	end,
 	
 	function(effect, player)
-		player:set_physics_override(1,nil,nil)
+		player:set_physics_override({speed = 1})
 	end
 )
 
 -- Makes the user faster (hidden effect)
 playereffects.register_effect_type("high_speed_hidden", "High speed", nil, {"speed"}, 
 	function(player)
-		player:set_physics_override(4,nil,nil)
+		player:set_physics_override({speed = 4})
 	end,
 	
 	function(effect, player)
-		player:set_physics_override(1,nil,nil)
+		player:set_physics_override({speed = 1})
 	end,
 	true
 )
@@ -67,21 +67,21 @@ playereffects.register_effect_type("high_speed_hidden", "High speed", nil, {"spe
 -- Slows the user down
 playereffects.register_effect_type("low_speed", "Low speed", nil, {"speed"}, 
 	function(player)
-		player:set_physics_override(0.25,nil,nil)
+		player:set_physics_override({speed = 0.25})
 	end,
 	
 	function(effect, player)
-		player:set_physics_override(1,nil,nil)
+		player:set_physics_override({speed = 1})
 	end
 )
 
 -- Increases the jump height
 playereffects.register_effect_type("highjump", "Greater jump height", "playereffects_example_highjump.png", {"jump"},
 	function(player)
-		player:set_physics_override(nil,2,nil)
+		player:set_physics_override({jump = 2})
 	end,
 	function(effect, player)
-		player:set_physics_override(nil,1,nil)
+		player:set_physics_override({jump = 1})
 	end
 )
 

--- a/mods/MODULES/playerplus/init.lua
+++ b/mods/MODULES/playerplus/init.lua
@@ -146,7 +146,7 @@ minetest.register_globalstep(function(dtime)
 
 		-- set player physics
 		if not monoids and not pova_mod then
-			player:set_physics_override(def.speed, def.jump, def.gravity)
+			player:set_physics_override(def)
 		end
 --[[
 		print ("Speed: " .. def.speed

--- a/mods/mesecraft_bedrock/init.lua
+++ b/mods/mesecraft_bedrock/init.lua
@@ -4,12 +4,12 @@ bedrock.layer = -30912 -- This is the location of the bottom layer.
 bedrock.thickness = -30910 -- This is how many layers are on top of the bottom layer. NOTE: these layers are not just flat layers but are more randomized.
 bedrock.node = {name = "mesecraft_bedrock:bedrock"} -- This is the block used.
 
-local depth = tonumber(minetest.setting_get("mesecraft_bedrock_y"))
+local depth = tonumber(minetest.settings:get("mesecraft_bedrock_y"))
 if depth ~= nil then
 	bedrock.layer = depth
 end
 
-local layers = tonumber(minetest.setting_get("mesecraft_bedrock_layers"))
+local layers = tonumber(minetest.settings:get("mesecraft_bedrock_layers"))
 if layers ~= nil then
 	bedrock.thickness = layers
 end

--- a/mods/mesecraft_beds/functions.lua
+++ b/mods/mesecraft_beds/functions.lua
@@ -75,7 +75,7 @@ local function lay_down(player, pos, bed_pos, state, skip)
 		player:set_eye_offset({x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 0})
 		player:set_look_horizontal(math.random(1, 180) / 100)
 		player_api.player_attached[name] = false
-		player:set_physics_override(1, 1, 1)
+		player:set_physics_override({speed = 1, jump = 1, gravity = 1})
 		hud_flags.wielditem = true
 		player_api.set_animation(player, "stand" , 30)
 
@@ -97,7 +97,7 @@ local function lay_down(player, pos, bed_pos, state, skip)
 			y = bed_pos.y + 0.07,
 			z = bed_pos.z + dir.z / 2
 		}
-		player:set_physics_override(0, 0, 0)
+		player:set_physics_override({speed = 0, jump = 0, gravity = 0})
 		player:set_pos(p)
 		player_api.player_attached[name] = true
 		hud_flags.wielditem = false

--- a/mods/mesecraft_soundscapes/init.lua
+++ b/mods/mesecraft_soundscapes/init.lua
@@ -267,7 +267,7 @@ end
 local nodes_in_range = function(pos, search_distance, node_name)
 	minp = {x=pos.x-search_distance,y=pos.y-search_distance, z=pos.z-search_distance}
 	maxp = {x=pos.x+search_distance,y=pos.y+search_distance, z=pos.z+search_distance}
-	nodes = minetest.env:find_nodes_in_area(minp, maxp, node_name)
+	nodes = minetest.find_nodes_in_area(minp, maxp, node_name)
 	--minetest.chat_send_all("Found (" .. node_name .. ": " .. #nodes .. ")")
 	return #nodes
 end

--- a/mods/mesecraft_void_chest/init.lua
+++ b/mods/mesecraft_void_chest/init.lua
@@ -107,15 +107,4 @@ minetest.register_on_joinplayer(function(player)
 	local inv = player:get_inventory()
 	inv:set_size("mesecraft_void_chest:void_chest", 8*4)
 
-	--migrate from void_chest:void_chest to mesecraft_void_chest:void_chest
-	local vcCount = inv:get_size('void_chest:void_chest') -- should be 8*4 or 0
-	local stack
-	if vcCount and vcCount>1 then
-		for i = 1,vcCount do
-			stack = inv:get_stack('void_chest:void_chest', i)
-			stack = inv:add_item('mesecraft_void_chest:void_chest', stack) -- function returns items that couldn't be added
-			inv:set_stack('void_chest:void_chest', i, stack)
-		end
-	end
 end)
-

--- a/mods/mesecraft_void_chest/init.lua
+++ b/mods/mesecraft_void_chest/init.lua
@@ -106,5 +106,16 @@ end
 minetest.register_on_joinplayer(function(player)
 	local inv = player:get_inventory()
 	inv:set_size("mesecraft_void_chest:void_chest", 8*4)
+
+	--migrate from void_chest:void_chest to mesecraft_void_chest:void_chest
+	local vcCount = inv:get_size('void_chest:void_chest') -- should be 8*4 or 0
+	local stack
+	if vcCount and vcCount>1 then
+		for i = 1,vcCount do
+			stack = inv:get_stack('void_chest:void_chest', i)
+			stack = inv:add_item('mesecraft_void_chest:void_chest', stack) -- function returns items that couldn't be added
+			inv:set_stack('void_chest:void_chest', i, stack)
+		end
+	end
 end)
 


### PR DESCRIPTION
This PR updates the following deprecated calls:
* `minetest.setting_get()` --> `minetest.settings:get()`
* `minetest.env:find_nodes_in_area()` --> `minetest.find_nodes_in_area()`
